### PR TITLE
Update tables to include SXL/site configuration in YAML format

### DIFF
--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -217,10 +217,12 @@ elements and the titles in the signal exchange list (SXL).
    ============ ====================== ======================  ==================================
    Element      SXL (Excel)            SXL (YAML)              Description
    ============ ====================== ======================  ==================================
-   aCId         alarmCodeId                                    :term:`Alarm code id`
+   aCId         alarmCodeId            [alarmCodeId] [#f1]_    :term:`Alarm code id`
    xACId        externalAlarmCodeId    externalAlarmCodeId     :term:`External alarm code id`
    xNACId       externalNtsAlarmCodeId externalNtsAlarmcodeId  :term:`External NTS alarm code id`
    ============ ====================== ======================  ==================================
+
+.. [#f1] See :ref:`signal-exchange-list`
 
 The following table describes additional variable content of the message.
 
@@ -353,13 +355,15 @@ elements and the titles in the SXL.
 
 .. table::
 
-   =============  ============ ========== ===============================================
-   Element        SXL (Excel)  SXL (YAML) Description
-   =============  ============ ========== ===============================================
-   n              name                    Unique reference of the value
-   *(not sent)*   type         type       The :ref:`data type<data_types>` of the value
-   v              value                   Value from equipment
-   =============  ============ ========== ===============================================
+   =============  ============ ==================== ===============================================
+   Element        SXL (Excel)  SXL (YAML)           Description
+   =============  ============ ==================== ===============================================
+   n              Name         [argument id] [#f2]_ Unique reference of the value
+   *(not sent)*   Type         type                 The :ref:`data type<data_types>` of the value
+   v              Value                             Value from equipment
+   =============  ============ ==================== ===============================================
+
+.. [#f2] See :ref:`signal-exchange-list`
 
 .. _alarmmessages-req:
 
@@ -806,12 +810,14 @@ elements and the titles in the SXL.
 
 .. table:: Status request
 
-   ============ ============ ========== ===============================
-   Element      SXL (Excel)  SXL (YAML) Description
-   ============ ============ ========== ===============================
-   sCI          statusCodeId            :term:`Status code id`
-   n            name                    Unique reference of the value
-   ============ ============ ========== ===============================
+   ============ ============ ===================== ===============================
+   Element      SXL (Excel)  SXL (YAML)            Description
+   ============ ============ ===================== ===============================
+   sCI          statusCodeId [statusCodeId] [#f3]_ :term:`Status code id`
+   n            Name         [argument id] [#f3]_  Unique reference of the value
+   ============ ============ ===================== ===============================
+
+.. [#f3] See :ref:`signal-exchange-list`
 
 
 Structure for status response message
@@ -890,15 +896,17 @@ Return values ("sS") are always sent but can be empty if no return values exists
 
 .. table:: Return values (returnvalue)
 
-   =============   ============  =========== ==============================================
-   Element         SXL (Excel)   SXL (YAML)  Description
-   =============   ============  =========== ==============================================
-   sCI             statusCodeId              :term:`Status code id`
-   n               Name                      Unique reference of the value
-   *(not sent)*    Type          type        The :ref:`data type<data_types>` of the value.
-   s               Value                     Value
-   *(not sent)*    Comment       description Description for the status request.
-   =============   ============  =========== ==============================================
+   =============   ============  ====================== ==============================================
+   Element         SXL (Excel)   SXL (YAML)             Description
+   =============   ============  ====================== ==============================================
+   sCI             statusCodeId  [statusCodeId] [#f4]_  :term:`Status code id`
+   n               Name          [argument id] [#f4]_   Unique reference of the value
+   *(not sent)*    Type          type                   The :ref:`data type<data_types>` of the value.
+   s               Value                                Value from equipment
+   *(not sent)*    Comment       description            Description for the status request.
+   =============   ============  ====================== ==============================================
+
+.. [#f4] See :ref:`signal-exchange-list`
 
 The following table describes additional variable content of the message.
 
@@ -1282,17 +1290,18 @@ elements and the titles in the signal exchange list (SXL).
 
 .. table:: Command arguments defined by SXL
 
-   =============  ============== ============ ===============================================
-   Element        SXL (Excel)    SXL (YAML)   Description
-   =============  ============== ============ ===============================================
-   cCI            commandCodeId               :term:`Command code id`
-   *(not sent)*   Description    description  Description for the command request.
-   n              Name                        Unique reference of the value
-   cO             Command        command      Command
-   *(not sent)*   Type           type         The :ref:`data type<data_types>` of the value.
-   v              Value                       Value
-   =============  ============== ============ ===============================================
+   =============  ============== ====================== ===============================================
+   Element        SXL (Excel)    SXL (YAML)             Description
+   =============  ============== ====================== ===============================================
+   cCI            commandCodeId  [commandCodeId] [#f5]_ :term:`Command code id`
+   *(not sent)*   Description    description            Description for the command request.
+   n              Name           [argument] [#f5]_      Unique reference of the value
+   cO             Command        command                Command
+   *(not sent)*   Type           type                   The :ref:`data type<data_types>` of the value.
+   v              Value                                 Value
+   =============  ============== ====================== ===============================================
 
+.. [#f5] See :ref:`signal-exchange-list`
 
 Structure of a command response message
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1382,14 +1391,16 @@ between the JSon elements and the titles in the SXL.
 
 .. table:: Command return value defined by SXL
 
-   =============  ============== ============ ===============================================
-   Element        SXL (Excel)    SXL (YAML)   Description
-   =============  ============== ============ ===============================================
-   cCI            commandCodeId               :term:`Command code id`
-   n              Name                        Unique reference of the value
-   *(not sent)*   Type           type         The :ref:`data type<data_types>` of the value.
-   v              Value                       Value
-   =============  ============== ============ ===============================================
+   =============  ============== ====================== ===============================================
+   Element        SXL (Excel)    SXL (YAML)             Description
+   =============  ============== ====================== ===============================================
+   cCI            commandCodeId  [commandCodeId] [#f6]_ :term:`Command code id`
+   n              Name           [argument id] [#f6]_   Unique reference of the value
+   *(not sent)*   Type           type                   The :ref:`data type<data_types>` of the value.
+   v              Value                                 Value
+   =============  ============== ====================== ===============================================
+
+.. [#f6] See :ref:`signal-exchange-list`
 
 The following table describes additional variable content of the message.
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -110,20 +110,20 @@ The following table describes the variable content in all message types
 which is defined by the signal exchange list (SXL), except version
 messages, message acknowledgement messages and watchdog messages.
 
-The *SXL element* column describes the correlation between the JSon
-elements and the titles in the SXL.
+The *Site config* columns describes the correlation between the JSon
+elements and the titles in the :ref:`site-configuration`.
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.65}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.20}|\Yl{0.45}|
 
 .. table:: Variable content defined by SXL
 
-   ============ ============== ===================
-   Element      SXL element    Description
-   ============ ============== ===================
-   ntsOId       NTSObjectId    Component id for the NTS object which the  message is referring to.
-   xNId         externalNtsId  Identity for the NTS object in communication between NTS and other systems. The format is 5 integers. Defined in cooperation with representatives from NTS. Unique for the site.
-   cId          componentId    Component id for the object which the message is referring to.
-   ============ ============== ===================
+   ============ =================== ================== =======================
+   Element      Site config (Excel) Site config (YAML) Description
+   ============ =================== ================== =======================
+   ntsOId       NTSObjectId         ntsObjectId        :term:`Component id` for the :term:`NTS object`.
+   xNId         externalNtsId       externalNtsId      :term:`External NTS id`
+   cId          componentId         componentId        :term:`Component id`
+   ============ =================== ================== =======================
 
 .. _alarm-messages:
 
@@ -207,20 +207,20 @@ JSon code 3: An alarm message
 The following table describes the variable content of the message which is
 defined by the SXL.
 
-The *SXL element* column describes the correlation between the JSon
+The *SXL* columns describes the correlation between the JSon
 elements and the titles in the signal exchange list (SXL).
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.30}|\Yl{0.55}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.30}|\Yl{0.30}|\Yl{0.25}|
 
 .. table:: Alarm message
 
-   ============ ====================== =============
-   Element      SXL element            Description
-   ============ ====================== =============
-   aCId         alarmCodeId            Alarm suffix with in combination with the component id identifies an alarm. The examples in this document are defined according to the following format: *Ayyyy*, where *yyyy* is a unique number.
-   xACId        externalAlarmCodeId    Manufacturer specific alarm code and alarm description. Manufacturer, model, alarm code och additional alarm description.
-   xNACId       externalNtsAlarmCodeId Alarm code in order to identify alarm type during communication with NTS
-   ============ ====================== =============
+   ============ ====================== ======================  ==================================
+   Element      SXL (Excel)            SXL (YAML)              Description
+   ============ ====================== ======================  ==================================
+   aCId         alarmCodeId                                    :term:`Alarm code id`
+   xACId        externalAlarmCodeId    externalAlarmCodeId     :term:`External alarm code id`
+   xNACId       externalNtsAlarmCodeId externalNtsAlarmcodeId  :term:`External NTS alarm code id`
+   ============ ====================== ======================  ==================================
 
 The following table describes additional variable content of the message.
 
@@ -309,52 +309,20 @@ Alarms should not be sent unless:
 The following table describes the variable content of the message which is
 defined by the SXL.
 
-The *SXL element* column describes the correlation between the JSon
+The *SXL* columns describes the correlation between the JSon
 elements and the titles in the signal exchange list (SXL).
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.65}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.15}|\Yl{0.50}|
 
 .. table:: Alarm status details defined by SXL
 
-   +-------------------+--------------------+------------------------------------------------------------------------------------+
-   | Element           | SXL element        | Description                                                                        |
-   +===================+====================+====================================================================================+
-   | cat               | category           | A character, either **T** or **D**.                                                |
-   |                   |                    |                                                                                    |
-   |                   |                    | | An alarm belongs to one of these categories:                                     |
-   |                   |                    | | - T. Traffic alarm                                                               |
-   |                   |                    | | - D. Technical alarm                                                             |
-   |                   |                    |                                                                                    |
-   |                   |                    | **Traffic alarm:**                                                                 |
-   |                   |                    | Traffic alarms indicate events in the traffic related functions or the technical   |
-   |                   |                    | processes that effects traffic.                                                    |
-   |                   |                    |                                                                                    |
-   |                   |                    | | A couple of examples from a tunnel:                                              |
-   |                   |                    | | - Stopped vehicle                                                                |
-   |                   |                    | | - Fire alarm                                                                     |
-   |                   |                    | | - Error which affects message to motorists                                       |
-   |                   |                    | | - High level of :math:`CO_{2}` in traffic room                                   |
-   |                   |                    | | - Etc.                                                                           |
-   |                   |                    |                                                                                    |
-   |                   |                    | **Technical alarm:**                                                               |
-   |                   |                    | Technical alarms are alarms that do not directly affect the traffic. One example   |
-   |                   |                    | of a technical alarm is when an impulse fan stops working.                         |
-   +-------------------+--------------------+------------------------------------------------------------------------------------+
-   | *(not sent)*      | description        | Description of the alarm. Defined in SXL but is never actually sent.               |
-   |                   |                    | The format of the description is free of choice but has the following              |
-   |                   |                    | requirements:                                                                      |
-   |                   |                    |                                                                                    |
-   |                   |                    | - The text is unique for the object type                                           |
-   |                   |                    | - The text is defined in cooperation with the Purchaser before use                 |
-   +-------------------+--------------------+------------------------------------------------------------------------------------+
-   | pri               | priority           | The priority of the alarm.                                                         |
-   |                   |                    | The following values are defined:                                                  |
-   |                   |                    |                                                                                    |
-   |                   |                    | 1. Alarm that requires immediate action.                                           |
-   |                   |                    | 2. Alarm that does not require immediate action, but action is planned during      |
-   |                   |                    |    the next work shift.                                                            |
-   |                   |                    | 3. Alarm that will be corrected during the next planned maintenance shift.         |
-   +-------------------+--------------------+------------------------------------------------------------------------------------+
+   ============= ============ =========== ========================
+   Element       SXL (Excel)  SXL (YAML)  Description
+   ============= ============ =========== ========================
+   cat           category     category    :ref:`alarm-category`
+   *(not sent)*  description  description :ref:`alarm-description`
+   pri           priority     priority    :ref:`alarm-priority`
+   ============= ============ =========== ========================
 
 .. _return-values:
 
@@ -378,23 +346,20 @@ be empty (i.e. **[]**) if no return values are defined.
 The following table describes the content for each return value which is
 defined by the signal exchange list (SXL).
 
-The *SXL element* column describes the correlation between the JSon
+The *SXL* columns describes the correlation between the JSon
 elements and the titles in the SXL.
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.70}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.15}|\Yl{0.55}|
 
 .. table::
 
-   +-----------------+--------------------+-----------------------------------------------+
-   | Element         | SXL element        | Description                                   |
-   +=================+====================+===============================================+
-   | n               | name               | Unique reference of the value                 |
-   +-----------------+--------------------+-----------------------------------------------+
-   | *(not sent)*    | type               | The :ref:`data type<data_types>` of the value.|
-   |                 |                    | Defined in the SXL but is not actually sent   |
-   +-----------------+--------------------+-----------------------------------------------+
-   | v               | value              | Value from equipment                          |
-   +-----------------+--------------------+-----------------------------------------------+
+   =============  ============ ========== ===============================================
+   Element        SXL (Excel)  SXL (YAML) Description
+   =============  ============ ========== ===============================================
+   n              name                    Unique reference of the value
+   *(not sent)*   type         type       The :ref:`data type<data_types>` of the value
+   v              value                   Value from equipment
+   =============  ============ ========== ===============================================
 
 .. _alarmmessages-req:
 
@@ -693,22 +658,23 @@ The following tables are describing the variable content of the message:
    ======= ============= =====================================================================
 
 The following table describes the variable content defined by the signal
-exchange list (SXL). The *SXL element* column describes the correlation
+exchange list (SXL). The *SXL* columns describes the correlation
 between the JSon elements and the titles in the SXL.
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.25}|\Yl{0.60}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.25}|\Yl{0.25}|\Yl{0.45}|
 
 .. table:: Aggregated status SXL content
 
-   ======= =================== =============================================================
-   Element SXL element         Description
-   ======= =================== =============================================================
-   fP      functionalPosition  Functional position. |br|
-                               Is ``null`` or empty string if no value is defined in SXL.
-   fS      functionalState     Functional state. |br|
-                               Is ``null`` or empty string if no value is defined in SXL.
-   se      State               Array of eight booleans.
-   ======= =================== =============================================================
+   ======= =================== =================== ===========================
+   Element SXL (Excel)         SXL (YAML)          Description
+   ======= =================== =================== ===========================
+   fP      functionalPosition  functional_position :term:`Functional position`
+   fS      functionalState     functional_state    :term:`Functional state`
+   se      State               1-8                 Array of eight booleans
+   ======= =================== =================== ===========================
+
+``fP`` and ``fS`` is set to ``null`` or empty string if no value is defined
+in the SXL.
 
 State
 ~~~~~
@@ -831,21 +797,21 @@ once.
 
 The following table is describing the variable content of the message.
 
-The *SXL element* column describes the correlation between the JSon
+The *SXL* columns describes the correlation between the JSon
 elements and the titles in the SXL.
 
 .. _table-statusrequest:
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.65}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.20}|\Yl{0.45}|
 
 .. table:: Status request
 
-   ============ ============ ===================
-   Element      SXL element  Description
-   ============ ============ ===================
-   sCI          statusCodeId The Status code id. The examples is this document are defined according to the following format: *Syyyy*, where *yyyy* is a unique number.
-   n            name         Unique reference of the value
-   ============ ============ ===================
+   ============ ============ ========== ===============================
+   Element      SXL (Excel)  SXL (YAML) Description
+   ============ ============ ========== ===============================
+   sCI          statusCodeId            :term:`Status code id`
+   n            name                    Unique reference of the value
+   ============ ============ ========== ===============================
 
 
 Structure for status response message
@@ -893,14 +859,15 @@ The following table is describing the variable content of the message:
 
 .. table:: Status response
 
-   ======= ============= ======================================================================
+   ======= ============= ==============
    Element Value         Description
-   ======= ============= ======================================================================
-   sTs     *(timestamp)* Timestamp for the status.
-                         All timestamps are set at the site (and not in the supervision
-                         system) when the status is fetched (and not when the message is sent).
-                         See also the :ref:`data type<data_types>` section.
-   ======= ============= ======================================================================
+   ======= ============= ==============
+   sTs     *(timestamp)* Timestamp
+   ======= ============= ==============
+
+All timestamps are set at the site (and not in the supervision system) when
+the status is fetched (and not when the message is sent).
+See also the :ref:`data type<data_types>` section.
 
 Return values (returnvalue)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -919,29 +886,19 @@ Return values ("sS") are always sent but can be empty if no return values exists
 
 .. _table-statusresponse-returnvalues:
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.70}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.15}|\Yl{0.55}|
 
 .. table:: Return values (returnvalue)
 
-   +-----------------+--------------------+-----------------------------------------------+
-   | Element         | SXL element        | Description                                   |
-   +=================+====================+===============================================+
-   | sCI             | statusCodeId       | The Status code id.                           |
-   |                 |                    | The examples in this document are defined     |
-   |                 |                    | according to the following format: *Syyyy*,   |
-   |                 |                    | where *yyyy* is a unique number.              |
-   +-----------------+--------------------+-----------------------------------------------+
-   | n               | Name               | Unique reference of the value                 |
-   +-----------------+--------------------+-----------------------------------------------+
-   | *(not sent)*    | Type               | The :ref:`data type<data_types>` of the value.|
-   |                 |                    | Defined in the SXL but is not actually sent   |
-   +-----------------+--------------------+-----------------------------------------------+
-   | s               | Value              | Value                                         |
-   +-----------------+--------------------+-----------------------------------------------+
-   | *(not sent)*    | Comment            | Description for the status request.           |
-   |                 |                    | Defined in the SXL but is not actually        |
-   |                 |                    | sent.                                         |
-   +-----------------+--------------------+-----------------------------------------------+
+   =============   ============  =========== ==============================================
+   Element         SXL (Excel)   SXL (YAML)  Description
+   =============   ============  =========== ==============================================
+   sCI             statusCodeId              :term:`Status code id`
+   n               Name                      Unique reference of the value
+   *(not sent)*    Type          type        The :ref:`data type<data_types>` of the value.
+   s               Value                     Value
+   *(not sent)*    Comment       description Description for the status request.
+   =============   ============  =========== ==============================================
 
 The following table describes additional variable content of the message.
 
@@ -1021,7 +978,7 @@ The following table is describing the variable content of the message:
 
 .. table:: Status Request
 
-   ======== ========================
+   ======== ========== =============
    Element  Value      Description
    ======== ========== =============
    uRt      *(string)* updateRate
@@ -1318,34 +1275,24 @@ Values to send with the command (arguments)
 The following table describes the variable content of the message which is
 defined by the SXL.
 
-The *SXL element* column describes the correlation between the JSon
+The *SXL* columns describes the correlation between the JSon
 elements and the titles in the signal exchange list (SXL).
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.65}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.20}|\Yl{0.25}|
 
 .. table:: Command arguments defined by SXL
 
-   +-----------------+--------------------+-----------------------------------------------+
-   | Element         | SXL element        | Description                                   |
-   +=================+====================+===============================================+
-   | cCI             | commandCodeId      | The unique code of a command request.         |
-   |                 |                    | The examples in this document are defined     |
-   |                 |                    | according to the following format: *Myyyy*,   |
-   |                 |                    | where *yyyy* is a unique number.              |
-   +-----------------+--------------------+-----------------------------------------------+
-   | *(not sent)*    | Description        | Description for the command request.          |
-   |                 |                    | Defined in the SXL but is not actually        |
-   |                 |                    | sent.                                         |
-   +-----------------+--------------------+-----------------------------------------------+
-   | n               | Name               | Unique reference of the value                 |
-   +-----------------+--------------------+-----------------------------------------------+
-   | cO              | Command            | Command                                       |
-   +-----------------+--------------------+-----------------------------------------------+
-   | *(not sent)*    | Type               | The :ref:`data type<data_types>` of the value.|
-   |                 |                    | Defined in the SXL but is not actually sent   |
-   +-----------------+--------------------+-----------------------------------------------+
-   | v               | Value              | Value                                         |
-   +-----------------+--------------------+-----------------------------------------------+
+   =============  ============== ============ ===============================================
+   Element        SXL (Excel)    SXL (YAML)   Description
+   =============  ============== ============ ===============================================
+   cCI            commandCodeId               :term:`Command code id`
+   *(not sent)*   Description    description  Description for the command request.
+   n              Name                        Unique reference of the value
+   cO             Command        command      Command
+   *(not sent)*   Type           type         The :ref:`data type<data_types>` of the value.
+   v              Value                       Value
+   =============  ============== ============ ===============================================
+
 
 Structure of a command response message
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1428,28 +1375,21 @@ be empty if not return values are defined.
    ========= ========= =============
 
 The following table describes the variable content defined by the signal
-exchange list (SXL). The *SXL element* column describes the correlation
+exchange list (SXL). The *SXL* columns describes the correlation
 between the JSon elements and the titles in the SXL.
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.65}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.20}|\Yl{0.65}|
 
 .. table:: Command return value defined by SXL
 
-   +-----------------+--------------------+-----------------------------------------------+
-   | Element         | SXL element        | Description                                   |
-   +=================+====================+===============================================+
-   | cCI             | commandCodeId      | The unique code of a command.                 |
-   |                 |                    | The examples in this document are defined     |
-   |                 |                    | according to the following format: *Myyyy*,   |
-   |                 |                    | where *yyyy* is a unique number.              |
-   +-----------------+--------------------+-----------------------------------------------+
-   | n               | Name               | Unique reference of the value                 |
-   +-----------------+--------------------+-----------------------------------------------+
-   | *(not sent)*    | Type               | The :ref:`data type<data_types>` of the value.|
-   |                 |                    | Defined in the SXL but is not actually sent   |
-   +-----------------+--------------------+-----------------------------------------------+
-   | v               | Value              | Value                                         |
-   +-----------------+--------------------+-----------------------------------------------+
+   =============  ============== ============ ===============================================
+   Element        SXL (Excel)    SXL (YAML)   Description
+   =============  ============== ============ ===============================================
+   cCI            commandCodeId               :term:`Command code id`
+   n              Name                        Unique reference of the value
+   *(not sent)*   Type           type         The :ref:`data type<data_types>` of the value.
+   v              Value                       Value
+   =============  ============== ============ ===============================================
 
 The following table describes additional variable content of the message.
 
@@ -1647,33 +1587,23 @@ JSon code 24: A RSMP / SXL message
 The following table describes the variable content of the message which is
 defined by the SXL.
 
-The *SXL element* column describes the correlation between the JSon
-elements and the titles in the signal exchange list (SXL).
+The *Site config* columns describes the correlation between the JSon
+elements and the titles in the site configuration.
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.65}|
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.20}|\Yl{0.20}|\Yl{0.45}|
 
-.. table:: Version information defined by SXL
+.. table:: Version information defined by site configuration
 
-   +-------------+--------------------+--------------------------------------------------------------------+
-   | Element     | SXL element        | Description                                                        |
-   +=============+====================+====================================================================+
-   | sId         | SiteId             | Site identity. Used in order to refer to a “logical” identity of a |
-   |             |                    | site.                                                              |
-   |             |                    |                                                                    |
-   |             |                    | At the STA, the following formats can be used:                     |
-   |             |                    |                                                                    |
-   |             |                    | - The site id from the STAs component id standard TDOK 2012:1171   |
-   |             |                    |   e.g. ”40100”.                                                    |
-   |             |                    | - It is also possible to use the full component id (TDOK 2012:1171)|
-   |             |                    |   of the grouped object in the site in case the site id part of    |
-   |             |                    |   the component id is insufficient in order to uniquely identify a |
-   |             |                    |   site.                                                            |
-   |             |                    |                                                                    |
-   |             |                    | All the site ids that are used in the RSMP connection are sent     |
-   |             |                    | in the message using an array (**siteId**)                         |
-   +-------------+--------------------+--------------------------------------------------------------------+
-   | SXL         | SXL revision       | Revision of SXL. E.g ”1.3”                                         |
-   +-------------+--------------------+--------------------------------------------------------------------+
+   ======= ==================== ================== ===========================
+   Element Site config (Excel)  Site config (YAML) Description
+   ======= ==================== ================== ===========================
+   sId     SiteId                                  :term:`Site id`
+   SXL     SXL revision         version            Revision of SXL. E.g ”1.3”
+   ======= ==================== ================== ===========================
+
+It is possible to use more than one site id in a single RSMP connection.
+Therefore the site ids that are used in the RSMP connection are sent
+in the message using an array with ``sId``.
 
 The following table describes additional variable content of the message.
 

--- a/source/applicability/site_configuration.rst
+++ b/source/applicability/site_configuration.rst
@@ -74,11 +74,18 @@ Where:
 * ``object-1`` is the name of the object. For instance "signal group 1"
 
 An object can either be categorized as a **single object** or **grouped
-object**. There must be at least one grouped object which is typically also
-the main component. Grouped objects are defined by **componentId** and
-**ntsObjectId** are being set equal. Single objects have a unique
-**componentId** but uses the **ntsObjectId** of their main component.
+object**, also known as the main component(s).
 
-**externalNtsId** is optional and only used if the object is intended to
-be sent to :term:`NTS`.
+The main component(s) is defined by **componentId** and **ntsObjectId** are
+being set equal. This means that the object is visible from NTS.
+
+Single objects have a unique **componentId** but uses the **ntsObjectId** of
+their main component.
+
+**externalNtsId** and **ntsObjectId** are optional and only used if the
+object is intended to be sent to :term:`NTS`.
+
+.. note::
+   :term:`NTS` is used at the :term:`STA`. Other road authorities typically
+   leaves the `xNid` and `ntsOid` as empty strings.
 

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -99,6 +99,63 @@ position`.
 At least one argument are required for command and statuses, but they are
 optional in alarms.
 
+.. _alarm-description:
+
+Alarm description
+^^^^^^^^^^^^^^^^^
+Description of the alarm. Defined in SXL but is not sent.
+
+The format of the description is free of choice but has the following
+requirements:
+- Description is unique for the object type
+- Description is defined in cooperation with the Purchaser before use
+
+.. _alarm-category:
+
+Alarm category
+^^^^^^^^^^^^^^
+The alarm category is defined in the SXL by a single character, either
+``T`` or ``D``.
+
+==========  ===============
+Value       Description
+==========  ===============
+T           Traffic alarm
+D           Technical alarm
+==========  ===============
+
+A **traffic alarm** indicates events in the traffic related functions or the
+technical processes that affects traffic.
+
+A couple of examples from a tunnel:
+
+- Stopped vehicle
+- Fire alarm
+- Error which affects message to motorists
+- High level of :math:`CO_{2}` in traffic room
+- etc.
+
+**Technical alarms** are alarms that do not directly affect the traffic.
+One example of technical alarm is when an impulse fan stops working.
+
+.. _alarm-priority:
+
+Alarm priority
+^^^^^^^^^^^^^^
+The priority of the alarm.
+
+Defined in the SXL as a single character, ``1``, ``2`` or ``3``.
+
+The following values are defined:
+
+=====  ==============================
+Value  Description
+=====  ==============================
+1      Alarm that requires immediate action.
+2      Alarm that does not require immediate action, but action is planned during the next work shift.
+3      Alarm that will be corrected during the next planned maintenance shift.
+=====  ==============================
+
 Functional differences between message types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The following table defines the functional differences between message types.

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -66,12 +66,14 @@ Using the YAML format; each message type is defined like this:
           description: alarm description text
           priority: 1
           category: D
+          externalAlarmCodeId: manufacturer specific alarm text
+          externalNtsAlarmCodeId: 0000
           arguments:
             argument-1:
               type: integer
               min: 0
               max: 10
-              descrition: A0001 argument 1
+              description: A0001 argument 1
       statuses:
         S0001:
           description: status description text
@@ -89,8 +91,13 @@ Using the YAML format; each message type is defined like this:
 
   ..
 
-This example defines the alarm A0001, status S0001 and command M0001.
-Each with one argument named "argument-1" using integer, string and boolean
+This example defines:
+
+- An alarm with the :term:`alarm code id` ``A0001``
+- A status with the :term:`status code id` ``S0001``
+- A command with the :term:`command code id` ``M0001``.
+
+Each with one argument named ``argument-1`` using integer, string and boolean
 data types.
 
 It also defines the aggregated status (only bit 1 and 2) and :term:`functional

--- a/source/definitions.rst
+++ b/source/definitions.rst
@@ -5,17 +5,37 @@ Definitions
 
 .. glossary::
 
+   Alarm code id
+       Identity of an alarm
+
+       The examples in this document are defined according to the following
+       format: *Ayyyy*, where *yyyy* is a unique number.
+
+   Command code id
+       Identity of a command
+
+       The examples in this document are defined according to the following
+       format: *Myyyy* where *yyyy* is a unique number.
+
+   External alarm code id
+       Manufacturer specific alarm code and alarm description.
+       Includes manufacturer, model, internal alarm code och additional
+       alarm description.
+
+   External NTS alarm code id
+       Alarm code in order to identify alarm type during communication with NTS
+
    Aggregated object
        An aggregated object consists of one or many other objects.
        E.g. Component group (CG)
 
    Component
-       A component is an object or NTS object.
+       A component is an :term:`object` or :term:`NTS object`.
 
-       A component is identified using component-id.
+       A component is identified using component id.
 
-   Component-ID
-       A component-id identifies components.
+   Component id
+       Identity of a :term:`component`
 
        The format used for the STA’s sites is specified in the STA
        publication TDOK 2012:1171, e.g. AA+BBCDD=EEEFFGGG.
@@ -54,21 +74,21 @@ Definitions
       STA’s support system for maintenance
 
    NTS
-      National Traffic management system at the STA.
+      National Traffic management system at the :term:`STA`.
 
-   NTS Object
-       Used for objects in NTS
+   NTS object
+       Used for objects in :term:`NTS`
 
        All control and supervision related functions in NTS consist of
        NTS objects.
 
        An NTS object can represent one or many objects.
 
-       An NTS objects is identified in the communication interface
-       using “externalNtsId”. NTS can not use the format used in
-       component-id.
+   External NTS id
+       Identitiy for an :term:`NTS object` used in communication between NTS and other systems
 
-       An object and NTS object and use the same component-id.
+       The format is 5 integers and is unique for the site.
+       It is defined in cooperation with representatives from NTS.
 
    NTS-Object type
        A NTS object type is a classification of NTS objects.
@@ -86,16 +106,16 @@ Definitions
        An object can represent physical equipment or abstract concepts
        E.g. a camera, a control flow algorithm or a group of signs.
 
-       An object is identified using the objects component id. *Please
-       note that an object is not necessarily the same thing as an NTS
-       object.*
+       An object is identified using :term:`component id`.
+       *Please note that an object is not necessarily the same thing as an
+       NTS object.*
 
    Object type
        An object type is a classification of objects that controls the
        properties of all the objects of the same object type. The
        object type determines how the object is presented in
        supervision system, how it is grouped and which functional
-       positions, alarm codes, commands and statuses that exists that
+       positions, alarm codes, commands and statuses that exists for that
        object type.
 
    Parameter
@@ -112,6 +132,20 @@ Definitions
    Site
        See :term:`ITS site`
 
+   Site id
+       Site identity.
+       Used in order to refer to a “logical” identity of a site.
+
+       At the STA, the following formats can be used:
+
+       - The site id from the STAs component id standard TDOK 2012:1171
+         e.g. ”40100”
+
+       - It is also possible to use the full component id (TDOK 2012:1171)
+         of the grouped object in the site in case the site id part of
+         the component id is insufficient in order to uniquely identify a
+         site.
+
    STA
        Swedish Transport Administration
 
@@ -123,6 +157,12 @@ Definitions
       Signal exchange list. Defines which messages types (signals)
       which is possible to send to a specific equipment or object.
       E.g. alarms, statuses and commands
+
+   Status code id
+      Identitiy for a status
+
+      The examples in this document are defined according to the following
+      format: *Syyyy* where *yyyy* is a unique number.
 
    TCP/IP
        Transfer Control Protocol/Internet Protocol


### PR DESCRIPTION
Many tables assumes that the SXL is defines in the Excel format.

This PR updates all tables which includes references to the SXL and site configuration.
It also moves definitions out from the tables and into it's own section.