### PR TITLE
Clarify the error case when object type doesn't match the signal

### DIFF
--- a/source/applicability/error_handling.rst
+++ b/source/applicability/error_handling.rst
@@ -36,9 +36,9 @@ MessageNotAck.
 
 This includes:
 
-* unknown alarm code id (``aCId``)
-* unknown status code id (``sCI``)
-* unknown command code id (``cCI``)
+* unknown alarm/status/command code id (``aCId``, ``sCI``, ``cCI``) for the
+  corresponding object type
+
 * unknown name (``n``) in arguments or return values
 
 Unimplemented statuses or commands

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -26,6 +26,7 @@ The full list of changes between version 3.2.2 and 3.2.1 can be viewed on github
 - Clarify communication establishment between sites. :issue:`156`
 - Update tables to include SXL/site configuration in YAML format. :issue:`159`
 - Clarify that alarm priority affects state bits 3,4 and 5. :issue:`162`
+- Clarify the error case when object type doesn't match the signal :issue:`164`
 
 Version 3.2.1
 -------------


### PR DESCRIPTION
Clarify the error when no alarm/status/command code id exist for the corresponding object type

Original discussion here: https://github.com/rsmp-nordic/rsmp_core/issues/163