### PR TITLE
allow all JSON types

### DIFF
--- a/source/applicability/data_types.rst
+++ b/source/applicability/data_types.rst
@@ -2,9 +2,24 @@
 
 Data types
 ----------
-RSMP uses a specific set of data types in return values and arguments of alarms, statuses and commands.
+RSMP uses JSON types for argument, attributes and return values:
 
-General definition:
+- object (hash)
+- array
+- string
+- number
+- boolean
+- null
+
+
+For historic reasons, the following elements can be send as strings:
+
+- number, e.g. "56". Follow the ECMA standard. A dot "." is used as decimal point for floating point numbers.
+- arrays, e.g. "1,2,3". Items are separated using commmas. Whitespace is not allowed before or after commas.
+- booleans, can be either "true" or "false".
+
+
+The following specialized data types are defined. They are all send as JSON strings:
 
 .. tabularcolumns:: |\Yl{0.15}|\Yl{0.85}|
 
@@ -13,19 +28,12 @@ General definition:
 
    * - Data type
      - Description
-   * - string
-     - Text information
-   * - integer
-     - JSON integer according to the ECMA standard
-   * - number
-     - JSON numerical value. Can be either integer or floating point according to the ECMA standard
-   * - boolean
-     - Boolean data type
    * - base64
-     - Binary data expressed in base64 format according to RFC-4648
+     - Binary data expressed in base64 format according to RFC-4648, e.g. "TWFs", which represents the binary sequence 010011010110000101101100.
    * - timestamp
-     - The timestamp uses the W3C XML dateTime definition with 3 decimal places. All timestamps uses UTC.
-   * - array
-     - List of values. Makes it possible to send multiple values of any data type or list of key and value pairs. Content defined by SXL.
+     - The timestamp uses the W3C XML dateTime definition with 3 decimal places. All timestamps uses UTC. Eg. "2019-09-26T12:54:54.066Z".
 
-Point (".") is always used as decimal mark.
+
+Signal Exchange Lists (SXLs) specifiy which types are allowed in particular statuses, alarms and commands.
+
+


### PR DESCRIPTION
Updates section 4.6 to allow all JSON types.

The following types can still be send as strings: numbers, arrays and booleans. We could switch to JSON types, which would be a lot cleaner, but would be a breaking change (so not for 3.3).

We still define the following custom types (send as JSON strings): base64 binary and timestamps.
