### PR TITLE
Lean status attributes

### DIFF
--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1000,8 +1000,10 @@ The following applies:
   2 seconds (triggering sendOnChange) the updateRate timer starts over and
   waits another 5 seconds to trigger.
 
-* It is not valid to set **updateRate=0** and **sendOnChange=false** since
-  it means that no subscription updates will be sent.
+* If **updateRate=0** and **sendOnChange=false** lazy updates is used.
+ A change of the attribute will not trigger a status update, but
+  the attribute will be included whenever another attribute with the same
+  sCI triggers an update.
 
 * It is allowed to change **updateRate** and **sendOnChange** by sending a
   new StatusSubscribe during an active subscription.

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1000,7 +1000,7 @@ The following applies:
   2 seconds (triggering sendOnChange) the updateRate timer starts over and
   waits another 5 seconds to trigger.
 
-* If **updateRate=0** and **sendOnChange=false** lean updating is used.
+* If **updateRate="0"** and **sendOnChange=false** lean updating is used.
   A change of the attribute will not trigger a status update, but
   the attribute will be included whenever another attribute with the same
   sCI triggers an update.

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1000,8 +1000,8 @@ The following applies:
   2 seconds (triggering sendOnChange) the updateRate timer starts over and
   waits another 5 seconds to trigger.
 
-* If **updateRate=0** and **sendOnChange=false** lazy updates is used.
- A change of the attribute will not trigger a status update, but
+* If **updateRate=0** and **sendOnChange=false** lean updating is used.
+  A change of the attribute will not trigger a status update, but
   the attribute will be included whenever another attribute with the same
   sCI triggers an update.
 


### PR DESCRIPTION
implements #189 

uRt=0 and sOc=false indicate a lean attribute, only send if another attribute trigger an update.