### PR TITLE
use 'component' rather than 'object' consistently

### DIFF
--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -901,7 +901,7 @@ The following table describes additional variable content of the message.
    +=================+====================+===============================================+
    | q               | recent             | The value is up to date                       |
    |                 +--------------------+-----------------------------------------------+
-   |                 | old                | The value is not up to date.                  |
+   |                 | old                | The value is not up to date                   |
    |                 |                    | Used when sending buffered values             |
    |                 +--------------------+-----------------------------------------------+
    |                 | undefined          | The component does not exist                  |

--- a/source/applicability/site_configuration.rst
+++ b/source/applicability/site_configuration.rst
@@ -48,20 +48,20 @@ It contains:
 Objects
 -------
 
-A site consists of objects, identified by unique component ids (``cId``).
+A site consists of components, identified by unique component ids (``cId``).
 
-Using the Excel format; objects are defined in it's own sheet - one for each
+Using the Excel format; components are defined in it's own sheet - one for each
 site.
-Using the YAML format, each object is defined like this:
+Using the YAML format, each component is defined like this:
 
 .. code-block:: yaml
 
   sites:
     site-id:
       description: site description
-      objects:
-        object-type:
-          object-1:
+      components:
+        component-type:
+          component-1:
             componentId: AA+BBCCC=DDDEEFFF
             ntsObjectId: AA+BBCCC=DDDEEFFF
             externalNtsId: 00000
@@ -70,23 +70,23 @@ Where:
 
 * ``site-id`` is the site id. This is needed during initial handshake
 * ``site description``. Site description
-* ``object-type`` defines which object type the object belongs to
-* ``object-1`` is the name of the object. For instance "signal group 1"
+* ``component-type`` defines which object type the component belongs to
+* ``component-1`` is the name of the component. For instance "signal group 1"
 * ``componentId`` is the :term:`Component id`
 * ``ntsObjectId`` is the :term:`Component id` for the :term:`NTS object`
 * ``externalNtsId`` is the :term:`External NTS id`
 
-An object can either be categorized as a **single object** or **grouped
-object**, also known as the main component(s).
+A component can either be categorized as a **single component** or **grouped
+component**, also known as the main component(s).
 
 The main component(s) is defined by **componentId** and **ntsObjectId** are
-being set equal. This means that the object is visible from NTS.
+being set equal. This means that the component is visible from NTS.
 
-Single objects have a unique **componentId** but uses the **ntsObjectId** of
+Single components have a unique **componentId** but uses the **ntsObjectId** of
 their main component.
 
 **externalNtsId** and **ntsObjectId** are optional and only used if the
-object is intended to be sent to :term:`NTS`.
+component is intended to be sent to :term:`NTS`.
 
 .. note::
    :term:`NTS` is used at the :term:`STA`. Other road authorities typically

--- a/source/applicability/site_configuration.rst
+++ b/source/applicability/site_configuration.rst
@@ -70,7 +70,7 @@ Where:
 
 * ``site-id`` is the site id. This is needed during initial handshake
 * ``site description``. Site description
-* ``component-type`` defines which object type the component belongs to
+* ``component-type`` defines which component type the component belongs to
 * ``component-1`` is the name of the component. For instance "signal group 1"
 * ``componentId`` is the :term:`Component id`
 * ``ntsObjectId`` is the :term:`Component id` for the :term:`NTS object`

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -50,7 +50,7 @@ Using the YAML format; each message type is defined like this:
 .. code-block:: yaml
 
   components:
-    comnponent-type:
+    component-type:
       aggregated_status:
         1:
           title: Local mode

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -29,7 +29,7 @@ Using the YAML format; each object type is defined like this:
    components:
      component-type:
 
-Where ``commponent-type`` is the name of the object type. For instance,
+Where ``component-type`` is the name of the object type. For instance,
 "Traffic Light Controller".
 
 Depending on applicability, each object type can either have it's own

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -14,10 +14,10 @@ possible to send and receive for each object type.
 The SXL can be defined by either a YAML file or an Excel file using predefined
 principles which is defined below.
 
-Object types
+Component types
 ------------
 
-An **object type** defines a type of object that can exist in a site,
+An **component type** defines a type of component that can exist in a site,
 i.e. "LED". Each object type can have a set of alarms, statuses and
 commands associated with it.
 
@@ -26,10 +26,10 @@ Using the YAML format; each object type is defined like this:
 
 .. code-block:: yaml
 
-   objects:
-     object-type:
+   components:
+     component-type:
 
-Where ``object-type`` is the name of the object type. For instance,
+Where ``commponent-type`` is the name of the object type. For instance,
 "Traffic Light Controller".
 
 Depending on applicability, each object type can either have it's own
@@ -49,8 +49,8 @@ Using the YAML format; each message type is defined like this:
 
 .. code-block:: yaml
 
-  objects:
-    object-type:
+  components:
+    comnponent-type:
       aggregated_status:
         1:
           title: Local mode

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -130,7 +130,7 @@ implicit in the following figure.
    statuses are allowed to be sent
 
 9. Aggregated status (according to section :ref:`aggregated-status-message`).
-   If no object for aggregated status is defined in the signal exchange list
+   If no component for aggregated status is defined in the signal exchange list
    then no aggregated status message is sent.
 
 10. All alarms (including active, inactive, suspended, unsuspended and acknowledged)
@@ -205,7 +205,7 @@ implicit in the following figure.
    statuses are allowed to be sent
 
 9. Aggregated status (according to section :ref:`aggregated-status-message`)
-   If no object for aggregated status is defined in the signal exchange list
+   If no component for aggregated status is defined in the signal exchange list
    then no aggregated status message is sent.
 
 For communication between sites the following applies:

--- a/source/purpose.rst
+++ b/source/purpose.rst
@@ -12,8 +12,8 @@ guidelines. This means that the protocol, as opposed to many other
 standards and protocols do not include detailed information about the
 signal exchange but is focused on defining the types of signals which
 are then described construction or items specifically. The goal is
-that in the long term, based on installed systems and objects, is to
-be able to produce signal exchange lists of type object that can be
+that in the long term, based on installed systems and components, is to
+be able to produce signal exchange lists of type component that can be
 reused in new contracts so that alarm messages, commands, etc. have
 the same names regardless of facility or provider.
 
@@ -56,5 +56,5 @@ facilities and equipment. The four message types are:
   subscription (either at status change or at set time interval).
 
 - **Command**. Commands sent from a supervision system or other
-  facility to alter the equipment / object status or control
+  facility to alter the equipment / component status or control
   principle.


### PR DESCRIPTION
Use 'component' consistently, not 'object'. I used Claude Sonnet 4 to find places to change.

In this PR I propose changing the YAML format as well:

```yaml
objects:
  object-type:
```

=>

```yaml
components:
  component-type:
```

This will require is to change our yaml source and tooling. But since i don't think anyone else is yet using yaml source, i think it's better to change it now to be consistent. Thoughs on that?