### PR TITLE
'alarms' flag in Version message, update section on multiple supervisors

### DIFF
--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1596,7 +1596,7 @@ The following table describes additional variable content of the message.
    Element       Type     Description
    ============= ======== ===============
    vers          string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
-   receiveAlarms boolean  Set to false if the supervisor does not want to receive alarms
+   receiveAlarms boolean  Supervisor can set this to false if they do not want to receive alarms.
    ============= ======== ===============
 
 The `receiveAlarms` attribute is optional and can only be set in the Version response

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1565,13 +1565,6 @@ the example below the system has support for RSMP version **3.1.1**,
 
 JSon code 24: A RSMP / SXL message
 
-Note that `alarms` is optional and can only be set by supervisors. If a
-site receives a Version message from a supervisor with the flag
-set to false, the site must not send any Alarm message to that supervisor,
-except if the supervisor requests an alarm.
-All supervisor can send alarm requests, aknowledgements and suspends,
-even if the `alarms` flag was set to false.
-
 The following table describes the variable content of the message which is
 defined by the SXL.
 
@@ -1603,7 +1596,10 @@ The following table describes additional variable content of the message.
    Element  Type     Description
    ======== ======== ===============
    vers     string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
-   alarms   boolean  Supervisors set this to false if they do not want to receive alarms.
+   alarms   boolean  The `alarms` attribute is optional and can only be set in the Version response
+					 send by the supervisors, not the initial Version request send by the site.
+					 If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests an alarm.
+					 The supervisor can request, aknowledge and suspend/resume alarms even if the `alarms` attribute was set to false.
    ======== ======== ===============
 
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1565,9 +1565,11 @@ the example below the system has support for RSMP version **3.1.1**,
 
 JSon code 24: A RSMP / SXL message
 
-Note that `alarms` is optional and can only be set by supervisors, not
-sites. If a site receives a Version message from a supervisor with the flag
-set to false, it should not send any Alarm message to that supervisor.
+Note that `alarms` is optional and must only be set by supervisors. If a
+site receives a Version message from a supervisor with the flag
+set to false, it must not send any Alarm message to that supervisor, and
+the supervisor is not allowed to send any alarm requests or state changes
+to the site. I.e. no Alarm messages can be send betweeen them.
 
 The following table describes the variable content of the message which is
 defined by the SXL.

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1603,7 +1603,7 @@ The `receiveAlarms` attribute is optional and can only be set in the Version res
 sent by the supervisors, not the initial Version request sent by the site.
 
 - If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests, suspends or acknowledges an alarm.
-- If set to true, or omitted, site must send all alarms to the supervisor as normal (unless suspended).
+- If set to true, or omitted, site must send alarms to the supervisor as normal.
 
 The supervisor can request, acknowledge and suspend/resume alarms even if the `receiveAlarms` attribute was set to false.
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1599,6 +1599,7 @@ The following table describes additional variable content of the message.
    alarms   boolean  The `alarms` attribute is optional and can only be set in the Version response
 					 send by the supervisors, not the initial Version request send by the site.
 					 If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests an alarm.
+                     If set to true, or omitted, site must send all alarms to the supervisor as normal (unless suspended).
 					 The supervisor can request, acknowledge and suspend/resume alarms even if the `alarms` attribute was set to false.
    ======== ======== ===============
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1588,7 +1588,7 @@ in the message using an array with ``sId``.
 
 The following table describes additional variable content of the message.
 
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.70}|
+.. tabularcolumns:: |\Yl{0.20}|\Yl{0.15}|\Yl{0.65}|
 
 .. table:: Version information
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1596,13 +1596,16 @@ The following table describes additional variable content of the message.
    Element       Type     Description
    ============= ======== ===============
    vers          string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
-   receiveAlarms boolean  The `receiveAlarms` attribute is optional and can only be set in the Version response
-                          sent by the supervisors, not the initial Version request send by the site.
-                          If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests, suspends or acknowledges an alarm.
-                          If set to true, or omitted, site must send all alarms to the supervisor as normal (unless suspended).
-                          The supervisor can request, acknowledge and suspend/resume alarms even if the `alarms` attribute was set to false.
+   receiveAlarms boolean  Set to false if the supervisor does not want to receive alarms
    ============= ======== ===============
 
+The `receiveAlarms` attribute is optional and can only be set in the Version response
+sent by the supervisors, not the initial Version request sent by the site.
+
+- If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests, suspends or acknowledges an alarm.
+- If set to true, or omitted, site must send all alarms to the supervisor as normal (unless suspended).
+
+The supervisor can request, acknowledge and suspend/resume alarms even if the `receiveAlarms` attribute was set to false.
 
 .. _watchdog:
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1516,7 +1516,7 @@ RSMP/SXL Version is the initial message when establishing communication.
 It contains:
 
 * Site Id
-* SXL revision
+* SXL versions
 * All supported RSMP versions
 
 The Site Id and SXL revision must match between the communicating parties.
@@ -1565,11 +1565,12 @@ the example below the system has support for RSMP version **3.1.1**,
 
 JSon code 24: A RSMP / SXL message
 
-Note that `alarms` is optional and must only be set by supervisors. If a
+Note that `alarms` is optional and can only be set by supervisors. If a
 site receives a Version message from a supervisor with the flag
-set to false, it must not send any Alarm message to that supervisor, and
-the supervisor is not allowed to send any alarm requests or state changes
-to the site. I.e. no Alarm messages can be send betweeen them.
+set to false, the site must not send any Alarm message to that supervisor,
+except if the supervisor requests an alarm.
+All supervisor can send alarm requests, aknowledgements and suspends,
+even if the `alarms` flag was set to false.
 
 The following table describes the variable content of the message which is
 defined by the SXL.

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1560,12 +1560,12 @@ the example below the system has support for RSMP version **3.1.1**,
             }
         ],
         "SXL": "1.0.13",
-        "wantAlarms": false
+        "alarms": false
    }
 
 JSon code 24: A RSMP / SXL message
 
-Note that `wantAlarms` is optional and can only be set by supervisors, not
+Note that `alarms` is optional and can only be set by supervisors, not
 sites. If a site receives a Version message from a supervisor with the flag
 set to false, it should not send any Alarm message to that supervisor.
 
@@ -1596,12 +1596,12 @@ The following table describes additional variable content of the message.
 
 .. table:: Version information
 
-   =========== ======== ===============
-   Element     Type     Description
-   =========== ======== ===============
-   vers        string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
-   wantAlarms  boolean  Supervisors can set this to false if they do not want to receive alarms.
-   =========== ======== ===============
+   ======== ======== ===============
+   Element  Type     Description
+   ======== ======== ===============
+   vers     string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
+   alarms   boolean  Supervisors set this to false if they do not want to receive alarms.
+   ======== ======== ===============
 
 
 .. _watchdog:

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1560,7 +1560,7 @@ the example below the system has support for RSMP version **3.1.1**,
             }
         ],
         "SXL": "1.0.13",
-        "alarms": false
+        "receiveAlarms": false
    }
 
 JSon code 24: A RSMP / SXL message
@@ -1592,16 +1592,16 @@ The following table describes additional variable content of the message.
 
 .. table:: Version information
 
-   ======== ======== ===============
-   Element  Type     Description
-   ======== ======== ===============
-   vers     string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
-   alarms   boolean  The `alarms` attribute is optional and can only be set in the Version response
-					 send by the supervisors, not the initial Version request send by the site.
-					 If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests an alarm.
-                     If set to true, or omitted, site must send all alarms to the supervisor as normal (unless suspended).
-					 The supervisor can request, acknowledge and suspend/resume alarms even if the `alarms` attribute was set to false.
-   ======== ======== ===============
+   ============= ======== ===============
+   Element       Type     Description
+   ============= ======== ===============
+   vers          string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
+   receiveAlarms boolean  The `receiveAlarms` attribute is optional and can only be set in the Version response
+                          sent by the supervisors, not the initial Version request send by the site.
+                          If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests an alarm.
+                          If set to true, or omitted, site must send all alarms to the supervisor as normal (unless suspended).
+                          The supervisor can request, acknowledge and suspend/resume alarms even if the `alarms` attribute was set to false.
+   ============= ======== ===============
 
 
 .. _watchdog:

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1559,10 +1559,15 @@ the example below the system has support for RSMP version **3.1.1**,
                 "sId": "O+14439=481WA001"
             }
         ],
-        "SXL": "1.0.13"
+        "SXL": "1.0.13",
+        "wantAlarms": false
    }
 
 JSon code 24: A RSMP / SXL message
+
+Note that `wantAlarms` is optional and can only be set by supervisors, not
+sites. If a site receives a Version message from a supervisor with the flag
+set to false, it should not send any Alarm message to that supervisor.
 
 The following table describes the variable content of the message which is
 defined by the SXL.
@@ -1591,11 +1596,13 @@ The following table describes additional variable content of the message.
 
 .. table:: Version information
 
-   ========= ======= ===============
-   Element   Type    Description
-   ========= ======= ===============
-   vers      string  Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
-   ========= ======= ===============
+   =========== ======== ===============
+   Element     Type     Description
+   =========== ======== ===============
+   vers        string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
+   wantAlarms  boolean  Supervisors can set this to false if they do not want to receive alarms.
+   =========== ======== ===============
+
 
 .. _watchdog:
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1599,7 +1599,7 @@ The following table describes additional variable content of the message.
    alarms   boolean  The `alarms` attribute is optional and can only be set in the Version response
 					 send by the supervisors, not the initial Version request send by the site.
 					 If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests an alarm.
-					 The supervisor can request, aknowledge and suspend/resume alarms even if the `alarms` attribute was set to false.
+					 The supervisor can request, acknowledge and suspend/resume alarms even if the `alarms` attribute was set to false.
    ======== ======== ===============
 
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1598,7 +1598,7 @@ The following table describes additional variable content of the message.
    vers          string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
    receiveAlarms boolean  The `receiveAlarms` attribute is optional and can only be set in the Version response
                           sent by the supervisors, not the initial Version request send by the site.
-                          If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests an alarm.
+                          If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests, suspends or acknowledges an alarm.
                           If set to true, or omitted, site must send all alarms to the supervisor as normal (unless suspended).
                           The supervisor can request, acknowledge and suspend/resume alarms even if the `alarms` attribute was set to false.
    ============= ======== ===============

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -78,7 +78,7 @@ Aggregated status:
 
 Status:
 
-* All supervisor can request, subscribe to and receive statuses.
+* All supervisors can request, subscribe to and receive statuses.
 * Status subscribtions are handled separate per supervisor.
 * A status response is sent only to the supervisor that sent the
   initiating status request.

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -67,7 +67,7 @@ Message Acknowledgements:
 
 Connection:
 
-* Connections to supervisor are handled in parallel, with messages procesesed
+* Connections to supervisor are handled in parallel, with messages processed
   in the order they arrive.
 * Depending on how core/SXL version are set in Version messages, the
   connections to supervisor can use different core/SXL versions.
@@ -78,7 +78,7 @@ Aggregated status:
 
 Status:
 
-* All supervisor and can request, subscribe to and receive statuses.
+* All supervisor can request, subscribe to and receive statuses.
 * Status subscribtions are handled separate per supervisor.
 * A status response is sent only to the supervisor that sent the
   initiating status request.

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -93,8 +93,8 @@ Commands:
 
 Alarms:
 
-* Alarms are sent to all supervisors, except those that set the `wantAlarms`
-  flag in their Version message to false.
+* Alarms are sent to all supervisors, except those that set `alarms`
+  to false in their Version message.
 * If an Alarm is blocked, suspended or acknowledged by a supervisor by a
   supervisor this affects all supervisors.
 

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -46,54 +46,55 @@ Multiple supervisors
   stated in the :term:`SXL`.
 
 Supervisor configuration:
+
 * It must be possible to configure the list of supervisors as part of the
   RSMP configuration in the site. In the configuration, supervisors are
   identified by their IP addresses or domain names.
-
 * It must be possible to configure whether to initiate the RSMP connection
   or to implement the socket server according to section
   :ref:`transport-between-site-and-supervision-system`.
 
 Message IDs:
+
 * All messages must have unique message ids. Even when otherwise identical
   messages are sent to multiple supervisors, (e.g. an alarm or status update)
   different messages IDs must be used.
 
 Message Acknowledgements:
+
 * Message acknowledgements are send only to the supervisor that send the
   original message.
 
 Connection:
+
 * Connections to supervisor are handled in parallel, with messages procesesed
   in the order they arrive.
-
 * Depending on how core/SXL version are set in Version messages, the
   connections to supervisor can use different core/SXL versions.
 
 Aggregated status:
+
 * Aggregated status is send to all supervisors.
 
 Status:
+
 * All supervisor and can request, subscribe to and receive statuses.
-
 * Status subscribtions are handled separate per supervisor.
-
 * A status response is sent only to the supervisor that sent the
   initiating status request.
 
 Commands:
-* All supervisors can send commands.
 
+* All supervisors can send commands.
 * Commands from multiple supervisors are served on a first-come basis,
   without any concept of priority.
-
 * A command response is sent only to the supervisor that send the
   initiating command.
 
 Alarms:
+
 * Alarms are sent to all supervisors, except those that set the `wantAlarms`
   flag in their Version message to false.
-
 * If an Alarm is blocked, suspended or acknowledged by a supervisor by a
   supervisor this affects all supervisors.
 

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -95,7 +95,7 @@ Alarms:
 
 * Alarms are send to all supervisors, except those that set `alarms`
   to false in their Version message.
-* All supervisor can aknowledge and suspend/resume alarms, even if they
+* All supervisor can acknowledge and suspend/resume alarms, even if they
   set `alarms`to false in their Version message.
 * If an Alarm is blocked, suspended or acknowledged by one supervisor
   this affects all supervisors.

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -66,8 +66,8 @@ Each site needs to support the following:
 * Commands from multiple supervisors are served on a first-come basis,
   without any concept of priority.
 
-* Alarms are sent to all supervisor, except those that set the `wants_alarms`
-  flag in their Version reponses to false.
+* Alarms are sent to all supervisor, except those that set the `wantAlarms`
+  flag in their Version message to false.
 
 * If an Alarm is blocked, suspended or acknowledged by a supervisor, this
   affects all supervisors. The updated alarm is send to all supervisors.

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -74,12 +74,12 @@ Connection:
 
 Aggregated status:
 
-* Aggregated status is send to all supervisors.
+* Aggregated status is sent to all supervisors.
 
 Status:
 
 * All supervisors can request, subscribe to and receive statuses.
-* Status subscribtions are handled separate per supervisor.
+* Status subscriptions are handled separate per supervisor.
 * A status response is sent only to the supervisor that sent the
   initiating status request.
 
@@ -95,7 +95,7 @@ Alarms:
 
 * Alarms are send to all supervisors, except those that set `receiveAlarms`
   to false in their Version message.
-* All supervisor can acknowledge and suspend/resume alarms, even if they
+* All supervisors can acknowledge and suspend/resume alarms, even if they
   set `receiveAlarms` to false in their Version message.
 * If an Alarm is blocked, suspended or acknowledged by one supervisor
   this affects all supervisors.

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -42,38 +42,61 @@ Multiple supervisors
 ^^^^^^^^^^^^^^^^^^^^
 
 .. note::
-   Implementing support for multiple supervisors is not required unless
-   otherwise stated in the :term:`SXL`.
+  Implementing support for multiple supervisors is not required unless
+  stated in the :term:`SXL`.
 
-Each site needs to support the following:
-
+Supervisor configuration:
 * It must be possible to configure the list of supervisors as part of the
   RSMP configuration in the site. In the configuration, supervisors are
-  identified by their IP addresses.
+  identified by their IP addresses or domain names.
 
 * It must be possible to configure whether to initiate the RSMP connection
   or to implement the socket server according to section
   :ref:`transport-between-site-and-supervision-system`.
 
-* All supervisors receives aggregated statuses and can request,
-  subscribe and receive statuses.
+Message IDs:
+* All messages must have unique message ids. Even when otherwise identical
+  messages are sent to multiple supervisors, (e.g. an alarm or status update)
+  different messages IDs must be used.
 
-* A site must handle all types of messages from all supervisors, including
-  command requests, status requests and status subscriptions.
+Message Acknowledgements:
+* Message acknowledgements are send only to the supervisor that send the
+  original message.
 
-* Status subscribtions are handled per supervisor.
+Connection:
+* Connections to supervisor are handled in parallel, with messages procesesed
+  in the order they arrive.
+
+* Depending on how core/SXL version are set in Version messages, the
+ connections to supervisor can use different core/SXL versions.
+
+Aggregated status:
+* Aggregated status is send to all supervisors.
+
+Status:
+* All supervisor and can request, subscribe to and receive statuses.
+
+* Status subscribtions are handled separate per supervisor.
+
+* A status response is sent only to the supervisor that sent the
+  initiating status request.
+
+Commands:
+* All supervisors can send commands.
 
 * Commands from multiple supervisors are served on a first-come basis,
   without any concept of priority.
 
-* Alarms are sent to all supervisor, except those that set the `wantAlarms`
+* A command response is sent only to the supervisor that send the
+  initiating command.
+
+Alarms:
+* Alarms are sent to all supervisors, except those that set the `wantAlarms`
   flag in their Version message to false.
 
-* If an Alarm is blocked, suspended or acknowledged by a supervisor, this
-  affects all supervisors. The updated alarm is send to all supervisors.
+* If an Alarm is blocked, suspended or acknowledged by a supervisor by a
+  supervisor this affects all supervisors.
 
-* When a site receives a command or status request from a supervisor, the
-  response is sent only to that particular supervisor.
 
 Security
 ^^^^^^^^

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -51,30 +51,29 @@ Each site needs to support the following:
   RSMP configuration in the site. In the configuration, supervisors are
   identified by their IP addresses.
 
-* It must be possible to configure to either initiate the RSMP connection
+* It must be possible to configure whether to initiate the RSMP connection
   or to implement the socket server according to section
   :ref:`transport-between-site-and-supervision-system`.
 
-* It must be possible to configure supervisors as primary or secondary.
-
-* There can be multiple secondary supervisors, but only one primary.
-
-* A secondary supervisor does not receive alarms.
-
-* A secondary supervisor receives aggregated status and can request,
+* All supervisors receives aggregated statuses and can request,
   subscribe and receive statuses.
 
-* Watchdog messages from a secondary supervisor does not adjust the clock.
-  See section :ref:`watchdog`.
+* A site must handle all types of messages from all supervisors, including
+  command requests, status requests and status subscriptions.
 
-* Except from not sending alarms to secondary supervisors, a site must
-  handle all types of message from all supervisors, including command requests,
-  status requests and status subscriptions. Commands from multiple supervisors
-  are served on a first-come basis, without any concept of priority.
+* Status subscribtions are handled per supervisor.
 
-* Supervisor connections are handled separately. When a supervisor sends a
-  command or status request, the response is sent only to that particular
-  supervisor.
+* Commands from multiple supervisors are served on a first-come basis,
+  without any concept of priority.
+
+* Alarms are sent to all supervisor, except those that set the `wants_alarms`
+  flag in their Version reponses to false.
+
+* If an Alarm is blocked, suspended or acknowledged by a supervisor, this
+  affects all supervisors. The updated alarm is send to all supervisors.
+
+* When a site receives a command or status request from a supervisor, the
+  response is sent only to that particular supervisor.
 
 Security
 ^^^^^^^^

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -93,8 +93,10 @@ Commands:
 
 Alarms:
 
-* Alarms are sent to all supervisors, except those that set `alarms`
+* Alarms are send to all supervisors, except those that set `alarms`
   to false in their Version message.
+* All supervisor can aknowledge and suspend/resume alarms, even if they
+  set `alarms`to false in their Version message.
 * If an Alarm is blocked, suspended or acknowledged by one supervisor
   this affects all supervisors.
 

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -68,7 +68,7 @@ Connection:
   in the order they arrive.
 
 * Depending on how core/SXL version are set in Version messages, the
- connections to supervisor can use different core/SXL versions.
+  connections to supervisor can use different core/SXL versions.
 
 Aggregated status:
 * Aggregated status is send to all supervisors.

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -95,8 +95,8 @@ Alarms:
 
 * Alarms are sent to all supervisors, except those that set `alarms`
   to false in their Version message.
-* If an Alarm is blocked, suspended or acknowledged by a supervisor by a
-  supervisor this affects all supervisors.
+* If an Alarm is blocked, suspended or acknowledged by one supervisor
+  this affects all supervisors.
 
 
 Security

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -93,10 +93,10 @@ Commands:
 
 Alarms:
 
-* Alarms are send to all supervisors, except those that set `alarms`
+* Alarms are send to all supervisors, except those that set `receiveAlarms`
   to false in their Version message.
 * All supervisor can acknowledge and suspend/resume alarms, even if they
-  set `alarms`to false in their Version message.
+  set `receiveAlarms` to false in their Version message.
 * If an Alarm is blocked, suspended or acknowledged by one supervisor
   this affects all supervisors.
 


### PR DESCRIPTION
Fixes #233 and #128

Also updates the section on multiple supervisor to remove the concept or primary/secondary supervisor, since it's not needed anymore - all supervisors receive alarms, unlese they set the 'alarms' flag to false in their Version message.