### PR TITLE
Clarify use of alarm rvs values

### DIFF
--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -128,13 +128,18 @@ An alarm message is sent to the supervision system when:
 - An alarm is requested
 - An alarm is acknowledged
 - An alarm is being suspended / un-suspended
-- An active alarm is updated (ie. the return values change)
+
+An active alarm may also be updated when its return values change.
 
 An acknowledgment of an alarm does not cause a single alarm event to
 be acknowledged but all alarm events for the specific component with the
 associated alarm code id. This approach simplifies both in
 implementation but also in handling - if many alarms occur on the same
 equipment with short time intervals.
+
+Receivers should identify an alarm by the combination of component id
+(``cId``) and alarm code id (``aCId``). Return values provide details about an
+alarm and should not be used as part of its identity.
 
 The ability to request alarms is used in case the supervision system
 loses track of the latest state of the alarms.
@@ -151,12 +156,10 @@ Alarm messages are event driven and sent to the supervision system
 when the alarm occurs. Acknowledgement of alarms and alarm suspend
 messages are interaction driven.
 
-Details about an active alarm is provided in the `rvs` (Return ValueS) array.
-For all other alarm types, the `rvs` array must be empty. This includes when
-an alarm becomes inactive.
-
-If rvs values change for an active alarm, an new alarm messages is send.
-Active alarms must always include all rvs values, whether they changed or not.
+Details about an active alarm can be provided in the ``rvs`` (return values)
+array. If the return values of an active alarm change, the site may send a new
+alarm message. Receivers should treat it as an update to the existing alarm.
+See :ref:`return-values`.
 
 Alarm events are referring to 'active' (aSp:Issue), 'suspended' (aSp:Suspend)
 and 'acknowledged' (aSp:Acknowledged).
@@ -300,6 +303,7 @@ and dashed lines define possible changes controlled by user.
 Alarms should not be sent unless:
 
 * Alarms are unblocked and its state changes
+* The return values of an active alarm change
 * Alarms are sent as part of
   :ref:`communication-establishment-between-sites-and-supervision-system`
 * Alarms are explicitly requested using :ref:`alarmmessages-req`
@@ -323,17 +327,18 @@ defined by the SXL.
 Return values
 ~~~~~~~~~~~~~
 
-The return values ("rvs") array is used only by active alarms,
-to provide addional information about the alarm. E.g. it can
-be used to indicate what signal head and/or color has broken
-lamps.
+The return values (``rvs``) array provides additional information about an
+alarm. For example, it can indicate which signal head or lamp color is broken.
 
-If an active alarm has no return values, an empty array must be used.
+The ``rvs`` array is always sent in ``Issue`` messages and in ``Suspend`` or
+``Resume`` messages that report the alarm state. Other alarm message
+specializations do not require it.
 
-Active alarms must include all rvs values, not only those that changed.
-I.e. the latest active alarm message will always provide all details.
-
-For all other alarm types the rvs array must be empty.
+For an active alarm, senders should include all current return values, not only
+those that changed. Where ``rvs`` is required, it must be an empty array if the
+SXL defines no return values for the alarm. For messages that report an
+inactive alarm, ``rvs`` should also be an empty array, but receivers must accept
+non-empty arrays that conform to the SXL.
 
 .. tabularcolumns:: |\Yl{0.15}|\Yl{0.10}|\Yl{0.60}|
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -128,6 +128,7 @@ An alarm message is sent to the supervision system when:
 - An alarm is requested
 - An alarm is acknowledged
 - An alarm is being suspended / un-suspended
+- An active alarm is updated (ie. the return values change)
 
 An acknowledgment of an alarm does not cause a single alarm event to
 be acknowledged but all alarm events for the specific component with the
@@ -149,6 +150,13 @@ when unsuspending an alarm an alarm can be inactive and not acknowledged.
 Alarm messages are event driven and sent to the supervision system
 when the alarm occurs. Acknowledgement of alarms and alarm suspend
 messages are interaction driven.
+
+Details about an active alarm is provided in the `rvs` (Return ValueS) array.
+For all other alarm types, the `rvs` array must be empty. This includes when
+an alarm becomes inactive.
+
+If rvs values change for an active alarm, an new alarm messages is send.
+Active alarms must always include all rvs values, whether they changed or not.
 
 Alarm events are referring to 'active' (aSp:Issue), 'suspended' (aSp:Suspend)
 and 'acknowledged' (aSp:Acknowledged).
@@ -315,9 +323,17 @@ defined by the SXL.
 Return values
 ~~~~~~~~~~~~~
 
-Return values ("rvs") are used by alarm messages (but not by alarm
-acknowledgment or alarm suspend messages) and is always sent but can
-be empty (i.e. **[]**) if no return values are defined.
+The return values ("rvs") array is used only by active alarms,
+to provide addional information about the alarm. E.g. it can
+be used to indicate what signal head and/or color has broken
+lamps.
+
+If an active alarm has no return values, an empty array must be used.
+
+Active alarms must include all rvs values, not only those that changed.
+I.e. the latest active alarm message will always provide all details.
+
+For all other alarm types the rvs array must be empty.
 
 .. tabularcolumns:: |\Yl{0.15}|\Yl{0.10}|\Yl{0.60}|
 


### PR DESCRIPTION
Clarified that rvs is only filled in for active alarms, and all rvs values must be send, not only changed values.

Addresses #218.

However, it seems the documentation is inconsistent regarding whether the 'rvs' attribute should be included.

Can we require the rvs attribute to be present for active alarms, and left our for all other alarm types (inactive, request, acknowledge, suspend/resume, etc)?