### PR TITLE
Add a workflow to build the doc on pull_request pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+# This workflow builds the sphinx documentation but doesn't publish it
+
+name: Build Core
+
+on: [pull_request]
+
+jobs:
+  build-core:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out rsmp_core repository
+      uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install \
+              python3-sphinx \
+              python3-sphinx-rtd-theme \
+              texlive \
+              texlive-latex-extra \
+              texlive-humanities \
+              texlive-fonts-extra \
+              imagemagick \
+              librsvg2-bin \
+              latexmk \
+              graphviz \
+              mscgen
+    - name: Build rsmp_core
+      run: make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,8 @@ jobs:
         sudo apt-get -y install \
               python3-sphinx \
               python3-sphinx-rtd-theme \
-              texlive \
-              texlive-latex-extra \
-              texlive-humanities \
-              texlive-fonts-extra \
               imagemagick \
               librsvg2-bin \
-              latexmk \
               graphviz \
               mscgen
     - name: Build rsmp_core


### PR DESCRIPTION
This workflow tests that it is possible to build the documentation - without pushing it github docs.