### PR TITLE
Support for multiple SXLs; describe SXL hierearchy and dependencies, update Version message

### DIFF
--- a/manifests/traffic_light_manifest.yaml
+++ b/manifests/traffic_light_manifest.yaml
@@ -1,0 +1,7 @@
+meta:
+  created_at: "2026-01-02T12:00:00Z"
+  created_by: "sxl-tool v1.0.0"
+  format: "3.3.0"
+manifest:
+  traffic_light_controller: "1.7.2"
+  traffic_light_controller_advanced: "1.1.3"

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1685,7 +1685,7 @@ Message Structure of Response
 If the supervisor determines that core or SXL versions are incompatible, a MessageNotAck must be send
 and the connection closed, see :ref:`communication-rejection`.
 
-If version are compatible, the supervisor returns a Version response containing:
+If versions are compatible, the supervisor returns a Version response containing:
 
 * Supervisor ID.
 * RSMP core version to use.

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1603,7 +1603,7 @@ Message Structure of Request
 """"""""""""""""""""""""""""
 The initial Version request send by the site contains:
 
-* Site Id
+* Site Id.
 * Supported RSMP core versions
 * Supported SXLs and their versions
 
@@ -1644,7 +1644,7 @@ The following table describes variable content of the message:
    ============= ======== ===============
    subtype       string   Must be set to 'Request'.
    siteId        array    Array of site ids. Must contain exactly one object with ``sId`` set to the site id string.
-   RSMP          array    Array of supported core version. 
+   RSMP          array    Array of supported core versions. 
    SXL           string   Version of the primary SXL. Used for backward compatibility if RSMP < 3.3.0 is negotiated.
    SXLS          array    Array of supported SXLs. Each item is an object with the attributes ``id`` and ``version``.
    ============= ======== ===============
@@ -1687,10 +1687,10 @@ and the connection closed, see :ref:`communication-rejection`.
 
 If version are compatible, the supervisor returns a Version response containing:
 
-* Supervisor ID
-* RSMP core version to use
-* SXLs to use and their versions
-* receiveAlarms flags, indicating whether the supervisor wants to receive alarms
+* Supervisor ID.
+* RSMP core version to use.
+* SXLs to use and their versions.
+* receiveAlarms flag, indicating whether the supervisor wants to receive alarms.
 
 .. code-block:: json
    :name: json-version-response
@@ -1711,7 +1711,7 @@ If version are compatible, the supervisor returns a Version response containing:
 
 JSon code 25: A Version Response message
 
-In this example, the supervisor has selected RSMP core version 3.1.2.
+In this example, the supervisor has selected RSMP core version 3.3.0.
 
 It has selected the SXL "tlc" version 1.3.3, which is a later patch version than the site supports (1.3.0),
 but still compatible because it's the same minor version.

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1599,44 +1599,61 @@ establishment (See
 :ref:`communication-establishment-between-sites-and-supervision-system`
 and :ref:`communication-establishment-between-sites`).
 
-Message structure
-"""""""""""""""""
+Message Structure of Request
+""""""""""""""""""""""""""""
+The initial Version request send by the site contains:
 
-A version message has the structure according to the example below. In
-the example below the system has support for RSMP version **3.1.1**,
-**3.1.2** and SXL version **1.0.13** for site **O+14439=481WA001**.
+* Site Id
+* Supported RSMP core versions
+* Supported SXLs and their versions
 
 .. code-block:: json
-   :name: json-version
+   :name: json-version-request
 
    {
         "mType": "rSMsg",
         "type": "Version",
+        "subtype": "Request",
         "mId": "6f968141-4de5-42ff-8032-45f8093762c5",
-        "step": "Request"
         "RSMP": [
-            {
-                "vers": "3.1.1"
-            },{
-                "vers": "3.1.2"
-            }
+            { "vers": "3.1.1" },
+            { "vers": "3.1.2" }
         ],
         "siteId": [
-            {
-                "sId": "O+14439=481WA001"
-            }
+            { "sId": "O+14439=481WA001" }
         ],
-        "SXL": "1.0.13",
-        "receiveAlarms": false
+        "SXL": "1.3.0",
+        "SXLS": [
+            { "id": "tlc", "version": "1.3.0" },
+            { "id": "tlc/advanced", "version": "1.1.0" },
+            { "id": "sensor", "version": "1.0.6" }
+        ]
    }
 
-JSon code 24: A RSMP / SXL message
+JSon code 24: A Version Request message
 
-The following table describes the variable content of the message which is
-defined by the SXL.
 
-The *Site config* columns describes the correlation between the JSon
-elements and the titles in the site configuration.
+The following table describes variable content of the message:
+
+.. tabularcolumns:: |\Yl{0.20}|\Yl{0.15}|\Yl{0.65}|
+
+.. table:: Version information
+
+   ============= ======== ===============
+   Element       Type     Description
+   ============= ======== ===============
+   subtype       string   Must be set to 'Request'.
+   siteId        array    Array of site ids. Must contain exactly one object with ``sId`` set to the site id string.
+   RSMP          array    Array of supported core version. 
+   SXL           string   Version of the primary SXL. Used for backward compatibility if RSMP < 3.3.0 is negotiated.
+   SXLS          array    Array of supported SXLs. Each item is an object with the attributes ``id`` and ``version``.
+   ============= ======== ===============
+
+Only one site can use the same connection. The ``sId`` array must therefore contain
+exactly one element.
+
+The following table shows the correlation between the JSON
+elements and the site configuration defined in YAML and Excel formats.
 
 .. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.20}|\Yl{0.20}|\Yl{0.30}|
 
@@ -1646,14 +1663,64 @@ elements and the titles in the site configuration.
    Element Type     Site config (Excel)  Site config (YAML) Description
    ======= ======== ==================== ================== ===========================
    sId     string   SiteId                                  :term:`Site id`
-   SXL     string   SXL revision         version            Revision of SXL. E.g ”1.3”
+   SXL     string   SXL revision         version            Revision of the primary SXL.
+   SXLS    array    SXLs supported       sxls               SXLs supported and their versions
    ======= ======== ==================== ================== ===========================
 
-It is possible to use more than one site id in a single RSMP connection.
-Therefore the site ids that are used in the RSMP connection are sent
-in the message using an array with ``sId``.
+Items in the ``SXLS`` array must be an object with the following content:
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.20}|\Yl{0.20}|\Yl{0.30}|
 
-The following table describes additional variable content of the message.
+.. table:: SXLS item content
+
+   ======= ======== ====================
+   Element Type     Description  
+   ======= ======== ==================== 
+   id      string   SXL id, e.g. "tlc"             
+   version string   Version of the SXL, e.g ”1.3.0”. If the site supports multiple versions, the latest must be specified.
+   ======= ======== ====================
+
+Message Structure of Response
+"""""""""""""""""""""""""""""
+If the supervisor determines that core or SXL versions are incompatible, a MessageNotAck must be send
+and the connection closed, see :ref:`communication-rejection`.
+
+If version are compatible, the supervisor returns a Version response containing:
+
+* Supervisor ID
+* RSMP core version to use
+* SXLs to use and their versions
+* receiveAlarms flags, indicating whether the supervisor wants to receive alarms
+
+.. code-block:: json
+   :name: json-version-response
+
+   {
+         "mType": "rSMsg",
+         "type": "Version",
+         "subtype": "Response",
+         "mId": "6f968141-4de5-42ff-8032-45f8093762c5",
+         "RSMP": "3.3.0",
+         "supervisorId": "O+14439=481WA001",
+         "SXLS": [
+            { "id": "tlc", "version": "1.3.3" },
+            { "id": "sensor", "version": "1.0.2" }
+         ],
+         "receiveAlarms": false
+   }
+
+JSon code 25: A Version Response message
+
+In this example, the supervisor has selected RSMP core version 3.1.2.
+
+It has selected the SXL "tlc" version 1.3.3, which is a later patch version than the site supports (1.3.0),
+but still compatible because it's the same minor version.
+
+The supervisor has also selected the SXL "sensor" version 1.0.2, which is an earlier patch version than the site supports (1.0.6),
+but still compatible because it's the same minor version.
+
+The SXL "tlc/advanced" is not used, because the supervisor either does not support this SXL or does not have a compatible version.
+
+The following table describes variable content of the message:
 
 .. tabularcolumns:: |\Yl{0.20}|\Yl{0.15}|\Yl{0.65}|
 
@@ -1662,18 +1729,12 @@ The following table describes additional variable content of the message.
    ============= ======== ===============
    Element       Type     Description
    ============= ======== ===============
-   step          string   Must be set to 'Request' in the initial Version message sent by the site, and to 'Response' in the Version message returned by the supervisor.
-   vers          string   Version of RSMP. E.g. ”3.1.2”, ”3.1.3” or ”3.1.4”. All the supported RSMP versions are sent in the message using an array (**RSMP**).
-   receiveAlarms boolean  Supervisor can set this to false if they do not want to receive alarms.
+   subtype       string   Must be set to 'Response'.
+   RSMP          array    Core version used. Must contain exactly one element with the attribute ``vers`` set to the version string, e.g. "3.1.2". 
+   receiveAlarms boolean  Optional. If set to false the site must not send alarms to the supervisor.
    ============= ======== ===============
 
-The `receiveAlarms` attribute is optional and can only be set in the Version response
-sent by the supervisors, not the initial Version request sent by the site.
-
-- If set to false, the site must not send any alarm message to the supervisor except if the supervisor requests, suspends or acknowledges an alarm.
-- If set to true, or omitted, site must send alarms to the supervisor as normal.
-
-The supervisor can request, acknowledge and suspend/resume alarms even if the `receiveAlarms` attribute was set to false.
+The supervisor can always request, acknowledge and suspend/resume alarms even if the `receiveAlarms` attribute was set to false in the Version response.
 
 .. _watchdog:
 

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1668,7 +1668,8 @@ elements and the site configuration defined in YAML and Excel formats.
    ======= ======== ==================== ================== ===========================
 
 Items in the ``SXLS`` array must be an object with the following content:
-.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.20}|\Yl{0.20}|\Yl{0.30}|
+
+.. tabularcolumns:: |\Yl{0.15}|\Yl{0.15}|\Yl{0.70}|
 
 .. table:: SXLS item content
 

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -4,6 +4,9 @@ Signal Exchange List (SXL)
 ==========================
 A signal exchange list (:term:`SXL`) specifies the interface for a type of equipment or area of functionality.
 
+The interface consists of component types, and the alarm, command, and status messages
+used to interact with these component types.
+
 SXLs are machine-readable specifications, not executable artifacts.
 
 A site implements one or more SXLs, which together form the site interface, used to interact with the site.
@@ -17,7 +20,7 @@ resulting in a manifest of exact versions.
 
 SXL Definition
 --------------
-An SXL has a name and a version.
+An SXL is identified by it's name, and is published with a version.
 
 It defines component types, which are logical or physical parts of a site,
 and the alarm, command, and status messages used to interact with these component types.
@@ -28,14 +31,18 @@ It can declare dependencies on other SXLs, which allows it to rely on component 
 
 .. _sxl-name:
 
-SXL Name
-^^^^^^^^
-The SXL is identified by a name, for example ``traffic_light_controller``.
+SXL Name and Description
+^^^^^^^^^^^^^^^^^^^^^^^^
+An SXL is identified by a name, for example ``traffic_light_controller`` or ``tlc``.
 Names can contain only lowercase letters, digits, hyphens, underscores and forrward slashes.
+
+It also has description, which is a short descriptive text that.
 
 .. code-block:: yaml
 
+meta:
   name: traffic_light_controller
+  description: Nordic Traffic Light Controller Interface
 
 A site cannot use two SXLs with the same name. You should therefore take care
 in choosing names that are unique within the context where they will be used.
@@ -46,6 +53,11 @@ SXL Version
 ^^^^^^^^^^^
 An SXL has a version, e.g. "1.3.1", which must follow Semantic Versioning (SemVer) format.
 
+.. code-block:: yaml
+
+meta:
+  version: 1.3.1
+
 Given a version number MAJOR.MINOR.PATCH, you must increment the:
 
 MAJOR version when you make incompatible API changes
@@ -55,38 +67,71 @@ PATCH version when you make backward compatible bug fixes
 SXL versions are used to determine whether a site and the supervisor has compatible versions,
 as well as when resolving dependencies between SXLs.
 
+.. _sxl-prefix:
+
+SXL Prefix
+^^^^^^^^^^
+An SXL can optionally define a prefix which is prepended to all component types and message codes
+in the SXL.
+
+A prefix is a convenience feature that reduces the need to repeat the same prefix in all component types and message codes.
+It has functional significance. Implementations must still use the full component type and message code ids
+
+.. code-block:: yaml
+
+meta:
+  prefix: tlc/
+types:
+  group:
+    description: Signal group
+
+Here, the type defined will be ``tlc/group`` (``tlc/`` concatenated with ``group``).
+
+If you need to define component types or message codes with different prefixes in the same SXL,
+e.g. "sensor/radar" and "tlc/radar", a prefix cannot be used.
+
 .. _sxl-component-types:
 
 SXL Component Types
 ^^^^^^^^^^^^^^^^^^^
-SXLs can define component types, which represent the types of logical or physical parts of a site.
+An SXL defines the available :term:`component types<type>`. Components are the logical or physical part of a site.
 
-When defining alarms, commands and statuses, the component types are used to indicate what a message applies to.
-
-Each component type is identified by a :term:`type id`.
-Only lowercase letters, digits, hyphens, underscores and forward slashes are allowed.
+Only lowercase letters, digits, hyphens, underscores and forward slashes are allowed in component types.
 
 Component type ids must be unique within the SXL. 
 
 Component types can be organized into a hierarchy using forward slashes.
+You can use multiple levels if needed.
 
-For example, a traffic light controller SXL might define the type ``tlc/sg`` for signal groups
-and ``tlc/dl`` for detector logics. You can use several levels if needed.
+.. code-block:: yaml
+
+  types:
+    tlc/sg:
+      description: Signal group
+    tlc/dl:
+      description: Detector logic
+
+Each type must have a short description.
+
+Using an abbreviated version  of the SXL name as a scope for component types is often practical,
+but not required, please see the section on :ref:`sxl-scopes`.
 
 .. _sxl_codes:
 
-SXL Codes
-^^^^^^^^^
-An SXL can define alarms, commands and statuses, each identified by a :term:`code`.
+SXL Message Codes
+^^^^^^^^^^^^^^^^^
+An SXL can define alarms, commands and statuses, each identified by a :term:`message code`.
+
 Only lowercase letters, digits, hyphens, underscores and forward slashes are allowed.
 Codes must be unique within the SXL.
 
-Codes are used to identify specific alarms, commands and statuses when sending messages.
-
-Codes can be organized into a hierarchy using forward slashes.
+Message codes can be organized into a hierarchy using forward slashes.
 
 For example, a traffic light controller SXL might define the code id ``tlc/M0001``
-or ``tlc/plan/set`` for a command to set a time plan.
+or ``tlc/plan/set`` for a command to set the current time plan.
+
+Using an abbreviated version of the SXL name as a scope for message codes is often practical,
+but not required, please see the section on :ref:`sxl-scopes`.
 
 .. _sxl-message-types:
 
@@ -324,56 +369,52 @@ return values.
 
 SXL Composition
 ---------------
-A site interface is composed of the SXLs that the site supports.
-An SXL can depend on other SXLs.
 
-.. _sxl-prefixes:
+.. _sxl-scope:
 
-SXL Prefixes
-^^^^^^^^^^^^
-To ensure relevant SXLs can be used together, forward slashes should be used to
-organize component types and alarm, status, and command codes into hierarchies
-that avoid clashes.
+SXL Scopes
+^^^^^^^^^^
+Two SXLs that define the same component type or message code cannot be used together on the same site.
 
-While it's often practical to use a prefix that relate to
-the SXL name, e.g. ``tlc/`` for a traffic light controller SLX , this is not a requirement.
+To ensure relevant SXLs can be used together, forward slashes should therefore be used to
+scope component types and message codes into hierarchies that avoid clashes.
+
+While it's often practical to use a scope that relate to the SXL name, e.g. ``tlc/`` for a
+traffic light controller SLX , this is not a requirement.
 You have the freedom to organize types and codes as needed.
 
-For example, two SXLs with different names could both define types and codes under the same
- prefix ``tlc/``, e.g. ``tlc/sg`` in one SXL and ``tlc/dl`` in the other.
-This ccan be useful in case you want to split a big SXL into smaller SXLs, while keeping the same prefix,
-or if you want to create an extension SXL that adds new types and codes under an existing prefix.
+For example, two SXLs could define different component types and message codes, but placed under the same
+scope. For example, one SXL might define ``tlc/sg`` while another defines ``tlc/dl``.
+This can be useful in case you want to split a big SXL into smaller SXLs while keeping the same scope,
+or you  want to create an extension SXL that adds new types or codes under an existing scope.
 
-Two SXLs can also define the exact same code. This means you cannot use them together, but it can be
-useful if you want to create a replacement SXL that is compatible with an existing SXL.
+If two SXLs define the exact same component type or message code you cannot use the SXLs together.
+But it might be useful if you want to create a replacement SXL that is compatible with an existing SXL.
 
-To maintain backward compatibility, some existing SXLs might use codes without any forward slashes,
-e.g. a command code like ``M0001``. As long as you don't use another SXL with conflicting
-codes on the same site, this is not a problem.
+To maintain backward compatibility, some existing SXLs might use component types or message codes without
+any forward slashes, e.g. a component type like ``sg`` or a command code like ``M0001``.
+This works as long as you don't try to use another SXL with conflicting codes on the same site.
 
 .. _sxl-dependencies:
 
 SXL Dependencies
 ^^^^^^^^^^^^^^^^
-An SXL can list other SXLs as dependencies.
+An SXL can list other SXLs as dependencies. It can then rely on the definitions of component types and
+message codes in the dependency SXLs.
 
-When an SXL depend on another SXL, it can rely on the definitions of component types and alarm,
-status and command codes that the dependency SXL defines.
+For example, the SXL ``traffic_light_controller_advanced`` might depend on the SXL ``traffic_light_controller``.
+It can then define a command ``tlc/adaptive`` which operates the component type ``tlc/dl`` already defined in
+the ``traffic_light_controller`` SXL.
 
-For example, let's assume that the ``traffic_light_controller`` SXL defines a ``tlc/sg`` component type.
-If the ``traffic_light_controller_advanced`` SXL depends
-on ``traffic_light_controller``, then it can define a command that operates on the ``tlc/sg`` type of component.
-
-Dependencies are listed using the SXL names and a version requirement. The order of dependencies is not significant.
-
-For example, a radar SXL might depend on a more basic sensor SXL like this:
+Dependencies are listed using SXL names and a version requirement string.
+The order of dependencies is not significant.
 
 .. code-block:: yaml
 
   dependencies:
-    sensor: "~1.3"
+    traffic_light_controller: "~4.3"
 
-Requirements support exact version, comparison operators ``>``, ``>=``, ``<``, ``<=`` and the compatibility operator ``~``.
+Version requirement strings support exact version, comparison operators ``>``, ``>=``, ``<``, ``<=`` and the compatibility operator ``~``.
 
 .. list-table:: Version requirement operators
    :header: "Requirement", "Translation"
@@ -385,7 +426,7 @@ Requirements support exact version, comparison operators ``>``, ``>=``, ``<``, `
    * - "<2.0.0"
      - any version lower than 2.0.0
    * - "~1.3"
-     - any version compatible with 1.3 according to semantic versioning rules, i.e. >=1.3.0 and <2.0.0.
+     - any version from 1.3 compatible with it according to semantic versioning rules, i.e. >=1.3.0 and <2.0.0.
 
 Two comparison operators can be combined with ``and``:
 
@@ -395,20 +436,21 @@ Two comparison operators can be combined with ``and``:
     * - ">=1.3.0 and <2.0.0"
       - any version from 1.3.0 (inclusive) to 2.0.0 (exclusive)
 
-To ensure that dependency resolution works as intended, it's important to update
+To ensure that dependency resolution works as intended, you must update
 the SXL version correctly when making changes to an SXL, according to Semantic
-Versioning (SemVer) rules.
+Versioning (SemVer) rules, please see the section on :ref:`sxl-version`.
 
-Before an SXL, or SXL update, is published, dependency resolution must be performed to ensure that dependencies can be met.
-A manifest must be created as a result of the dependecy resolution and must be published together with the SXL.
+Before an SXL is published or updated, dependency resolution and reconciliation must be performed to ensure that dependencies can be met
+and that there are no clashing component types or message codes.
+Success results in a manifest which must be published together with the SXL.
 
-.. _sxl-site-specification:
+.. _sxl-interface:
 
-SXL Site Interface
-^^^^^^^^^^^^^^^^^^
+SXL Interface
+^^^^^^^^^^^^^
 A site can support one or more SXLs, which together form the site interface.
 
-The supported SXLs are specified using SXL names and exact versions:
+The supported SXLs are specified using SXL names and exact versions. Order is not significant.
 
 .. code-block:: yaml
 
@@ -416,53 +458,44 @@ The supported SXLs are specified using SXL names and exact versions:
     traffic_light_controller: 1.3.0
     public_priority: 2.1.0
 
-The site interface (list of SXLs) is transmitted in the Version message sent by the site as part of the connection handshake.
+The site interface is transmitted in the Version message sent by the site as part of the connection handshake.
 
-All types and message defined in the listed SXLs will be available to supervisor.
-Component types, alarms, commands and statuses from dependency SXLs will not be available. If you want them available,
-you must explicitely list relevant dependency SXL in the site interface.
+All component types and message codes defined in the listed SXLs must be implemented by the site.
+Component types and message codes from dependency SXLs will not be available, unless you explicitely list them in 
+the interface.
 
-Before the site interface can published (e.g as part of a firmware update or a reconfiguration), dependency resolution must
-be performed to ensure that all SXL dependencies are met and the interface is congruent.
+Before the site interface is published (e.g. as part of a software update or a reconfiguration), dependency resolution
+and reconciliation must be performed to ensure that the interface is congruent.
+The resulting manifest is not published.
 
 .. _sxl-processing:
 
 SXL Processing
 --------------
-An SXL is a machine-readable specification that can references other SXLs as dependencies.
-A site interface is a list of SXLs.
+Before an SXL or site interface is published or updated, dependencies must be resolved and reconciled.
 
-Before an SXL and site interface is published, dependencies must be resolved and reconciled.
-If both steps succeed, a manifest is created that lists exact versions of all SXLs, including (transitive) dependencies.
+If both steps succeed, a manifest is created which lists all SXLs with exact versions, including (transitive) dependencies.
 
-This should be done using an appropriate SXL processing tool that reads SXL definitions,
-resolves dependencies, creates manifests and checks for symbol clashes.
+This SXL processing should be done using an appropriate tool which reads SXL definitions,
+resolves dependencies, checks for symbol clashes and creates manifests.
 
 .. _sxl-dependency-resolution:
 
 SXL Dependency Resolution
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Dependency resolution must be performed before an SXL or site interface is published to establish a set of
-exact versions that satisfy all version requirements.
+Dependency resolution attempts to establish a set of exact SXL versions that satisfy all version requirements.
 
-Dependency resolution must be performed before an SXL or site interface is published to establish a set of exact
-versions that satisfy all version requirements.
-Dependency order is ignored: the resolver recursively collects all requirements (including transitive requirements)
-and deterministically selects the highest SemVer-compatible version for each SXL.
+Dependency order is ignored. All requirements (including transitive requirements) are collected recursively.
+The highest SemVer-compatible version for each SXL is then selected deterministically.
 
-If requirements are unsatisfiable or a cyclic dependency is detected, resolution fails.
-
-All version requirements must be met together, and no conflicting requirements or cyclic dependencies are allowed.
-
+If any version requirement is unsatisfiable or a cyclic dependency is detected, resolution fails.
 
 .. _sxl-reconcilitation::
 
 SXL Reconcilation
 ^^^^^^^^^^^^^^^^^
-Once a set of exact SXL version have been established by dependency resolution, they must be reconsiled to
-ensure that there are no symbol clashes.
-
-Reconcilitation checks that two SXL do not define the same component type or alarm, status or command code.
+Once a set of exact SXL version have been established by dependency resolution, they must be reconciled.
+Reconcilitation checks that no two SXLs define the same component type or message code.
 
 Identical definitions across SXLs are not allowed.
 
@@ -470,20 +503,29 @@ Identical definitions across SXLs are not allowed.
 
 SXL Manifest
 ^^^^^^^^^^^^
-If both dependency resolution and reconcilitation succeeds a manifest is created.
+If dependency resolution and reconcilitation succeeds, a manifest is created.
 
-A manifest represent a set of SXLs at exact version that satisfy all version requirements,
-and is guaranteed not to have any symbol clashes.
+A manifest represents a set of SXLs at exact versions that satisfy all version requirements,
+and is guaranteed not to have any conflicting component types or message codes.
 
 SXLs are listed using their names and exact versions, and must be ordered by name according to natural sorting.
 
 .. code-block:: yaml
 
+  meta:
+    created_at: 2025-01-05T12:00:00Z
+    created_by: sxl-tool v1.0.0
+    format: 3.3.0
   manifest:
     public_priority: 2.1.0
     traffic_light_controller: 1.3.0
     traffic_light_controller_advanced: 1.0.0
 
-When publishing an SXL the manifest must be included.
+The ``meta`` section contains metadata about the manifest itself, including:
+- ``created_at`` is the timestamp when the manifest was created
+- ``created_by`` is the tool and version used to create the manifest
+- ``format`` is the RSMP core version that the manifest conforms to
+
+When publishing an SXL, a valid manifest must be included.
 
 For a site interface, the manifest is not published directly, but is reflected in the Version message sent by the site.

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -20,7 +20,7 @@ SXL ID
 An SXL is identified by an ID, for example ``tlc``.
 IDs use UTF-8 and can contain only lowercase letters, digits, hyphens, underscores, full stop and forward slashes.
 
-SXLs IDs must be unique. A site or supervisor cannot use two SXLs with the same ID.
+SXL IDs must be unique. A site or supervisor cannot use two SXLs with the same ID.
 
 .. _sxl-name:
 

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -2,20 +2,25 @@
 
 Signal Exchange List (SXL)
 ==========================
-A signal exchange list (:term:`SXL`) defines the interface for a specific
-type of equipment or area of functionality.
+A signal exchange list (:term:`SXL`) is a specification of the interface for a specific type of equipment or area of functionality.
 
-A site can support one or more SXLs.
+A site can support (implement) one or more SXLs, which together form the site interface, used by the supervisor
+to monitor and interact with the site.
+
+An SXL can depend on other SXLs, which makes it possible to organize and compose SXL into reusable blocks.
 
 .. _sxl-definition:
 
 SXL Definition
 --------------
-An SXL defines component types, which are logical or physical parts of a site,
-and the alarm, command, and status messages used to interact with them.
+An SXL has a name and a version.
 
-It also details the meaning of aggregated status bits, functional positions
-and functional states.
+It defines component types, which are logical or physical parts of a site,
+and the alarm, command, and status messages used to interact with these component types.
+
+It also details the meaning of aggregated status bits, functional positions and functional states.
+
+It can declare dependencies on other SXLs, which allows it to rely on component types and message codes from these SXLs.
 
 .. _sxl-name:
 
@@ -78,6 +83,8 @@ Codes can be organized into a hierarchy using forward slashes.
 
 For example, a traffic light controller SXL might define the code id ``tlc/M0001``
 or ``tlc/plan/set`` for a command to set a time plan.
+
+.. _sxl-message-types:
 
 Message types
 ^^^^^^^^^^^^^
@@ -338,7 +345,6 @@ To maintain backward compatibility, some existing SXLs might use codes without a
 e.g. a command code like ``M0001``. As long as you don't use another SXL with conflicting
 codes on the same site, this is not a problem.
 
-.. _sxl-message-types:
 .. _sxl-dependencies:
 
 SXL Dependencies
@@ -346,7 +352,7 @@ SXL Dependencies
 An SXL can list other SXLs as dependencies.
 
 When an SXL depend on another SXL, it can rely on the definitions of component types and alarm,
-status and command codes the dependency.
+status and command codes that the dependency SXL defines.
 
 For example, let's assume that the ``traffic_light_controller`` SXL defines a ``tlc/sg`` component type.
 If the ``traffic_light_controller_advanced`` SXL depends
@@ -388,17 +394,50 @@ To ensure that dependency resolution works as intended, it's important to update
 the SXL version correctly when making changes to an SXL, according to Semantic
 Versioning (SemVer) rules.
 
+Before an SXL, or SXL update, is published, dependency resolution must be performed to ensure that dependencies can be met.
+A manifest must be created as a result of the dependecy resolution and must be published together with the SXL.
+
+.. _sxl-site-specification:
+
+SXL Site Interface
+^^^^^^^^^^^^^^^^^^
+A site can support one or more SXLs, which together form the site interface.
+
+The supported SXLs are specified using SXL names and exact versions:
+
+.. code-block:: yaml
+
+  interface:
+    traffic_light_controller: 1.3.0
+    public_priority: 2.1.0
+
+The component types, alarms, commands and statuses defined in the listed SXLs will be available to supervisor.
+Component types, alarms, commands and statuses from dependency SXLs will not be available. If you want them available,
+you must explicitely list that dependcy SXL in the site interface.
+
+Before the site interface is published (e.g as part of a firmware update or a reconfiguration), dependency resolution must
+be performed to ensure that all SXL dependencies are met and the interface is congruent.
+
+
 .. _sxl-processing:
 
 SXL Processing
 --------------
+An SXL is a specification, which sites and supervisors can implement. An SXL is therefore not compiled
+or run the way an implemention is.
 
-.. _sxl-dependency_resolution:
+But because an SXL can depend on other SXLs, it's important to check that the specified dependecies are congruent,
+before the SXL is published.
+
+This means that all dependencies must exist at the specified version, that there are no mutually impossible version requirements
+and no cycling dependencies.
+
+Dependency resolution must be also perfomed before a site interface is published.
+
+.. _sxl-dependency-resolution:
 
 SXL Dependency Resolution
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Before SXLs can be loaded, dependencies must be resolved. 
-
 Dependency resolution must be performed whenever the set of SXLs used by a site changes.
 For a site with a static set of SXLs, this can be part of a compilation or configuration step.
 

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -9,7 +9,7 @@ An SXL defines component types, which are logical or physical parts of a site,
 and the alarm, command and status message use to interact with them.
 
 It also details the meaning of aggregated status bits, functional positions
-and functional states,
+and functional states.
 
 A site can support one or more SXLs.
 
@@ -18,10 +18,9 @@ A site can support one or more SXLs.
 SXL ID
 ------
 An SXL is identified by an ID, for example ``tlc``.
-IDs use UFT-8 and can contain only lowercase letters, digits, hyphens, underscores, full stop and forward slashes.
+IDs use UTF-8 and can contain only lowercase letters, digits, hyphens, underscores, full stop and forward slashes.
 
 SXLs IDs must be unique. A site or supervisor cannot use two SXLs with the same ID.
-An SXL also has a human readable name, for example "Traffic Light Controller".
 
 .. _sxl-name:
 
@@ -41,7 +40,7 @@ Patch versions are for backwards compatible bug fixes.
 Minor versions are for backwards compatible new features.
 Major versions are for incompatible changes.
 
-This is used to determines whether a supervisor and a site supporting different versions of an SXL can use that SXL.
+This is used to determine whether a supervisor and a site supporting different versions of an SXL can use that SXL.
 
 Compatibility is also important for SXLs :ref:`dependencies<sxl-dependencies>`.
 
@@ -81,22 +80,22 @@ This ensures that the required versions are explicit.
 
 .. _sxl_codes:
 
-SXL Codes IDs
--------------
-An SXL can defines alarms, commands and statuses, which all have a :term:`code id`.
+SXL Code IDs
+------------
+An SXL can define alarms, commands and statuses, which all have a :term:`code id`.
 Codes must be unique within the SXL.
 
 Codes can use forward slashes to organize them in a hierarchy.
 
-For example, an ```tlc`` SXL for traffic light controller might use the code id ``M0001``
-or ```plan/set`` for a command to set a time plan.
+For example, a ``tlc`` SXL for traffic light controller might use the code id ``M0001``
+or ``plan/set`` for a command to set a time plan.
 
 When you send a command, status or alarm, the code must be qualified with the SXL ID. For example, a command defined as
 ``M0001`` in the ``tlc/advanced`` SXL must be sent using the code ``/tlc/advanced/M0001``.
 
 Sites that support only a single SXL must also accept codes without the SXL ID prefix.
 
-For example, a site using only the ``tlc`` SXL must must also accept the unqualified code ``M0001``.
+For example, a site using only the ``tlc`` SXL must also accept the unqualified code ``M0001``.
 
 
 Message types

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -2,12 +2,16 @@
 
 Signal Exchange List (SXL)
 ==========================
-A signal exchange list (:term:`SXL`) is a specification of the interface for a specific type of equipment or area of functionality.
+A signal exchange list (:term:`SXL`) specifies the interface for a type of equipment or area of functionality.
 
-A site can support (implement) one or more SXLs, which together form the site interface, used by the supervisor
-to monitor and interact with the site.
+SXLs are machine-readable specifications, not executable artifacts.
 
-An SXL can depend on other SXLs, which makes it possible to organize and compose SXL into reusable blocks.
+A site implements one or more SXLs, which together form the site interface, used to interact with the site.
+
+An SXL can depend on other SXLs, which makes it possible to organize and compose SXLs to facilitate reuse.
+
+Before publishing an SXL site interface, SXL dependency resolution must be performed to check dependencies,
+resulting in a manifest of exact versions.
 
 .. _sxl-definition:
 
@@ -320,6 +324,8 @@ return values.
 
 SXL Composition
 ---------------
+A site interface is composed of the SXLs that the site supports.
+An SXL can depend on other SXLs.
 
 .. _sxl-prefixes:
 
@@ -358,8 +364,7 @@ For example, let's assume that the ``traffic_light_controller`` SXL defines a ``
 If the ``traffic_light_controller_advanced`` SXL depends
 on ``traffic_light_controller``, then it can define a command that operates on the ``tlc/sg`` type of component.
 
-Dependencies are listed using the SXL names and a version requirement. The order
-of dependencies is not significant.
+Dependencies are listed using the SXL names and a version requirement. The order of dependencies is not significant.
 
 For example, a radar SXL might depend on a more basic sensor SXL like this:
 
@@ -411,74 +416,74 @@ The supported SXLs are specified using SXL names and exact versions:
     traffic_light_controller: 1.3.0
     public_priority: 2.1.0
 
-The component types, alarms, commands and statuses defined in the listed SXLs will be available to supervisor.
+The site interface (list of SXLs) is transmitted in the Version message sent by the site as part of the connection handshake.
+
+All types and message defined in the listed SXLs will be available to supervisor.
 Component types, alarms, commands and statuses from dependency SXLs will not be available. If you want them available,
-you must explicitely list that dependcy SXL in the site interface.
+you must explicitely list relevant dependency SXL in the site interface.
 
-Before the site interface is published (e.g as part of a firmware update or a reconfiguration), dependency resolution must
+Before the site interface can published (e.g as part of a firmware update or a reconfiguration), dependency resolution must
 be performed to ensure that all SXL dependencies are met and the interface is congruent.
-
 
 .. _sxl-processing:
 
 SXL Processing
 --------------
-An SXL is a specification, which sites and supervisors can implement. An SXL is therefore not compiled
-or run the way an implemention is.
+An SXL is a machine-readable specification that can references other SXLs as dependencies.
+A site interface is a list of SXLs.
 
-But because an SXL can depend on other SXLs, it's important to check that the specified dependecies are congruent,
-before the SXL is published.
+Before an SXL and site interface is published, dependencies must be resolved and reconciled.
+If both steps succeed, a manifest is created that lists exact versions of all SXLs, including (transitive) dependencies.
 
-This means that all dependencies must exist at the specified version, that there are no mutually impossible version requirements
-and no cycling dependencies.
-
-Dependency resolution must be also perfomed before a site interface is published.
+This should be done using an appropriate SXL processing tool that reads SXL definitions,
+resolves dependencies, creates manifests and checks for symbol clashes.
 
 .. _sxl-dependency-resolution:
 
 SXL Dependency Resolution
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Dependency resolution must be performed whenever the set of SXLs used by a site changes.
-For a site with a static set of SXLs, this can be part of a compilation or configuration step.
+Dependency resolution must be performed before an SXL or site interface is published to establish a set of
+exact versions that satisfy all version requirements.
 
-For sites that allow run-time changes to the set of SXLs, dependency resolution must be performed
-whenever SXLs are added, removed or updated.
+Dependency resolution must be performed before an SXL or site interface is published to establish a set of exact
+versions that satisfy all version requirements.
+Dependency order is ignored: the resolver recursively collects all requirements (including transitive requirements)
+and deterministically selects the highest SemVer-compatible version for each SXL.
 
-SXLs are resolved recursively using depth-first, in the order they are listed.
-Cyclic dependencies are not allowed and will cause dependency resolution to fail for the involved SXLs
+If requirements are unsatisfiable or a cyclic dependency is detected, resolution fails.
 
-All SXLs that can be fully resolved are included in the resulting manifest.
+All version requirements must be met together, and no conflicting requirements or cyclic dependencies are allowed.
+
+
+.. _sxl-reconcilitation::
+
+SXL Reconcilation
+^^^^^^^^^^^^^^^^^
+Once a set of exact SXL version have been established by dependency resolution, they must be reconsiled to
+ensure that there are no symbol clashes.
+
+Reconcilitation checks that two SXL do not define the same component type or alarm, status or command code.
+
+Identical definitions across SXLs are not allowed.
 
 .. _sxl-manifest:
 
 SXL Manifest
 ^^^^^^^^^^^^
-Dependency resolution results in an SXL manifest, which lists SXLs and their dependencies, and their exact versions.
+If both dependency resolution and reconcilitation succeeds a manifest is created.
+
+A manifest represent a set of SXLs at exact version that satisfy all version requirements,
+and is guaranteed not to have any symbol clashes.
+
+SXLs are listed using their names and exact versions, and must be ordered by name according to natural sorting.
 
 .. code-block:: yaml
 
   manifest:
+    public_priority: 2.1.0
     traffic_light_controller: 1.3.0
     traffic_light_controller_advanced: 1.0.0
-    public_priority: 2.1.0
 
-A manifest must represent a valid set of SXLs, where all dependencies are met.
+When publishing an SXL the manifest must be included.
 
-.. _sxl-loading:
-
-SXL Loading
-^^^^^^^^^^^
-Before the SXLs in a manifest can be used they must be loaded.
-
-The SXLs listed in the manifest is loaded one by one, in the order they are listed, at the exact version
-specified.
-
-If the SXL is not available at the specified version, or cannot be fetched, loading of that SXL fails.
-
-Loading an SXL involves reading athe list of component types and alarms, status and command codes it defines, and adding it to a combined symbol table.
-
-Loading an SXL fails if a symbol with the same id has already been defined by a previously loaded SXL in the manifest, in which case
-none of the symbols from the SXL is added to the symbol table.
-
-After loading all SXLs in the manifest, the combined symbol table contains all component types and alarm,
-status and command codes available for use.
+For a site interface, the manifest is not published directly, but is reflected in the Version message sent by the site.

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -2,39 +2,102 @@
 
 Signal Exchange List
 ====================
+A signal exchange list (:term:`SXL`) defines the interface for a specific
+type of equipment or area of functionality.
 
-The signal exchange list is an important functional part of RSMP.
-Since the contents of every message using RSMP is dynamic, a predefined
-signal exchange list (:term:`SXL`) is prerequisite in order to be able to
-establish communication.
+An SXL defines component types, which are logical or physical parts of a site,
+and the alarm, command and status message use to interact with them.
 
-The signal exchange list defines the alarms, commands and statuses which is
-possible to send and receive for each component type.
+It also details the meaning of aggregated status bits, functional positions
+and functional states,
 
-The SXL can be defined by either a YAML file or an Excel file using predefined
-principles which is defined below.
+A site can support one or more SXLs.
 
-Component types
----------------
+.. _sxl-id:
 
-A **component type** defines a type of component that can exist in a site,
-i.e. "LED". Each component type can have a set of alarms, statuses and
-commands associated with it.
+SXL ID
+------
+An SXL is identified by an ID, for example ``tlc``.
+IDs use UFT-8 and can contain only lowercase letters, digits, hyphens, underscores, full stop and forward slashes.
 
-Using the Excel format; components types are defined in it's own sheet.
-Using the YAML format; each component type is defined like this:
+SXLs IDs must be unique. A site or supervisor cannot use two SXLs with the same ID.
+An SXL also has a human readable name, for example "Traffic Light Controller".
 
-.. code-block:: yaml
+.. _sxl-name:
 
-   components:
-     <component-type>:
+SXL Name
+--------
+An SXL has a human readable name, for example "Traffic Light Controller".
 
-Where ``<component-type>`` is the name of the component type. For instance,
-"Traffic Light Controller".
+.. _sxl-version:
 
-Depending on applicability, each component type can either have it's own
-series or common series of alarm suffix (alarmCodeId), status codes
-(statusCodeId) and command codes (commandCodeId).
+SXL Version
+-----------
+An SXL has a version, e.g. "1.3.1", which must follow Semantic Versioning (SemVer) format:
+
+<major>.<minor>.<patch>.
+
+Patch versions are for backwards compatible bug fixes.
+Minor versions are for backwards compatible new features.
+Major versions are for incompatible changes.
+
+This is used to determines whether a supervisor and a site supporting different versions of an SXL can use that SXL.
+
+Compatibility is also important for SXLs :ref:`dependencies<sxl-dependencies>`.
+
+.. _sxl-dependencies:
+
+SXL Dependencies
+----------------
+An SXL can list other SXLs as dependencies.
+
+A dependency is listed using an SXL ID and a minimum version.
+For example, an SXL might list ``tlc`` version ``1.2.0`` as a dependency.
+
+When an SXL lists another SXL as a dependency, it can use the component types defined by it.
+It can also rely on alarms, statuses and commands defined by it.
+
+For example, if the ``tlc`` SXL defines a ``sg`` signal group component type,
+the ``tlc/advanced`` SXL can define a command that operate on this type of component.
+
+A site can only use an SXL if it also supports all its dependencies, at the required minimum versions.
+
+Cyclic dependencies are not allowed.
+
+.. _sxl-hierarchy:
+
+SXL Hierarchy
+-------------
+SXLs can be organized in a hierarchy by using forward slashes in their IDs.
+
+For example, ``tlc/advanced`` would be a child SXL of the parent SXL ``tlc``,
+which might define advanced features for traffic light controllers.
+
+A child SXL does not automatically inherit the component types, alarms, statuses or commands
+defined by the parent SXL.
+
+Instead it must explicitly list the parent SXL as a dependency, at a minimum version.
+This ensures that the required versions are explicit.
+
+.. _sxl_codes:
+
+SXL Codes IDs
+-------------
+An SXL can defines alarms, commands and statuses, which all have a :term:`code id`.
+Codes must be unique within the SXL.
+
+Codes can use forward slashes to organize them in a hierarchy.
+
+For example, an ```tlc`` SXL for traffic light controller might use the code id ``M0001``
+or ```plan/set`` for a command to set a time plan.
+
+When you send a command, status or alarm, the code must be qualified with the SXL ID. For example, a command defined as
+``M0001`` in the ``tlc/advanced`` SXL must be sent using the code ``/tlc/advanced/M0001``.
+
+Sites that support only a single SXL must also accept codes without the SXL ID prefix.
+
+For example, a site using only the ``tlc`` SXL must must also accept the unqualified code ``M0001``.
+
 
 Message types
 -------------

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -1,113 +1,93 @@
 .. _signal-exchange-list:
 
-Signal Exchange List
-====================
+Signal Exchange List (SXL)
+==========================
 A signal exchange list (:term:`SXL`) defines the interface for a specific
 type of equipment or area of functionality.
 
+A site can support one or more SXLs.
+
+.. _sxl-definition:
+
+SXL Definition
+--------------
 An SXL defines component types, which are logical or physical parts of a site,
-and the alarm, command and status message use to interact with them.
+and the alarm, command, and status messages used to interact with them.
 
 It also details the meaning of aggregated status bits, functional positions
 and functional states.
 
-A site can support one or more SXLs.
-
-.. _sxl-id:
-
-SXL ID
-------
-An SXL is identified by an ID, for example ``tlc``.
-IDs use UTF-8 and can contain only lowercase letters, digits, hyphens, underscores, full stop and forward slashes.
-
-SXL IDs must be unique. A site or supervisor cannot use two SXLs with the same ID.
-
 .. _sxl-name:
 
 SXL Name
---------
-An SXL has a human readable name, for example "Traffic Light Controller".
+^^^^^^^^
+The SXL is identified by a name, for example ``traffic_light_controller``.
+Names can contain only lowercase letters, digits, hyphens, underscores and forrward slashes.
+
+.. code-block:: yaml
+
+  name: traffic_light_controller
+
+A site cannot use two SXLs with the same name. You should therefore take care
+in choosing names that are unique within the context where they will be used.
 
 .. _sxl-version:
 
 SXL Version
------------
-An SXL has a version, e.g. "1.3.1", which must follow Semantic Versioning (SemVer) format:
+^^^^^^^^^^^
+An SXL has a version, e.g. "1.3.1", which must follow Semantic Versioning (SemVer) format.
 
-<major>.<minor>.<patch>.
+Given a version number MAJOR.MINOR.PATCH, you must increment the:
 
-Patch versions are for backwards compatible bug fixes.
-Minor versions are for backwards compatible new features.
-Major versions are for incompatible changes.
+MAJOR version when you make incompatible API changes
+MINOR version when you add functionality in a backward compatible manner
+PATCH version when you make backward compatible bug fixes
 
-This is used to determine whether a supervisor and a site supporting different versions of an SXL can use that SXL.
+SXL versions are used to determine whether a site and the supervisor has compatible versions,
+as well as when resolving dependencies between SXLs.
 
-Compatibility is also important for SXLs :ref:`dependencies<sxl-dependencies>`.
+.. _sxl-component-types:
 
-.. _sxl-dependencies:
+SXL Component Types
+^^^^^^^^^^^^^^^^^^^
+SXLs can define component types, which represent the types of logical or physical parts of a site.
 
-SXL Dependencies
-----------------
-An SXL can list other SXLs as dependencies.
+When defining alarms, commands and statuses, the component types are used to indicate what a message applies to.
 
-A dependency is listed using an SXL ID and a minimum version.
-For example, an SXL might list ``tlc`` version ``1.2.0`` as a dependency.
+Each component type is identified by a :term:`type id`.
+Only lowercase letters, digits, hyphens, underscores and forward slashes are allowed.
 
-When an SXL lists another SXL as a dependency, it can use the component types defined by it.
-It can also rely on alarms, statuses and commands defined by it.
+Component type ids must be unique within the SXL. 
 
-For example, if the ``tlc`` SXL defines a ``sg`` signal group component type,
-the ``tlc/advanced`` SXL can define a command that operate on this type of component.
+Component types can be organized into a hierarchy using forward slashes.
 
-A site can only use an SXL if it also supports all its dependencies, at the required minimum versions.
-
-Cyclic dependencies are not allowed.
-
-.. _sxl-hierarchy:
-
-SXL Hierarchy
--------------
-SXLs can be organized in a hierarchy by using forward slashes in their IDs.
-
-For example, ``tlc/advanced`` would be a child SXL of the parent SXL ``tlc``,
-which might define advanced features for traffic light controllers.
-
-A child SXL does not automatically inherit the component types, alarms, statuses or commands
-defined by the parent SXL.
-
-Instead it must explicitly list the parent SXL as a dependency, at a minimum version.
-This ensures that the required versions are explicit.
+For example, a traffic light controller SXL might define the type ``tlc/sg`` for signal groups
+and ``tlc/dl`` for detector logics. You can use several levels if needed.
 
 .. _sxl_codes:
 
-SXL Code IDs
-------------
-An SXL can define alarms, commands and statuses, which all have a :term:`code id`.
+SXL Codes
+^^^^^^^^^
+An SXL can define alarms, commands and statuses, each identified by a :term:`code`.
+Only lowercase letters, digits, hyphens, underscores and forward slashes are allowed.
 Codes must be unique within the SXL.
 
-Codes can use forward slashes to organize them in a hierarchy.
+Codes are used to identify specific alarms, commands and statuses when sending messages.
 
-For example, a ``tlc`` SXL for traffic light controller might use the code id ``M0001``
-or ``plan/set`` for a command to set a time plan.
+Codes can be organized into a hierarchy using forward slashes.
 
-When you send a command, status or alarm, the code must be qualified with the SXL ID. For example, a command defined as
-``M0001`` in the ``tlc/advanced`` SXL must be sent using the code ``/tlc/advanced/M0001``.
-
-Sites that support only a single SXL must also accept codes without the SXL ID prefix.
-
-For example, a site using only the ``tlc`` SXL must also accept the unqualified code ``M0001``.
-
+For example, a traffic light controller SXL might define the code id ``tlc/M0001``
+or ``tlc/plan/set`` for a command to set a time plan.
 
 Message types
--------------
-
-The message types **Alarm**, **Aggregated status**, **Status** and **Commands**
+^^^^^^^^^^^^^
+The message types **Aggregated status**, **Alarm**, **Status** and **Commands**
 are defined in the SXL.
 
-Using the Excel format; alarms, aggregated status, status and commands are
-defined in their own sheet.
+Using the Excel format: alarms, aggregated status, statuses, and commands are
+defined in their own sheets.
 
-Using the YAML format; each message type is defined like this:
+Using the YAML format: each message type is defined like this:
 
 .. code-block:: yaml
 
@@ -200,8 +180,7 @@ An argument contains the fields:
 - ``max`` is the maximum value (only for *number* or *integer* data types)
 - ``type`` is the :ref:`data type<data_types>`
 
-At least one argument are required for command and statuses, but they are
-optional in alarms.
+At least one argument is required for commands and statuses; arguments are optional for alarms.
 
 
 .. note::
@@ -235,7 +214,7 @@ requirements:
 
 Alarm category
 ^^^^^^^^^^^^^^
-The alarm category is defined in by a single character, either ``T`` or ``D``.
+The alarm category is defined by a single character, either ``T`` or ``D``.
 
 ==========  ===============
 Value       Description
@@ -294,14 +273,14 @@ The following table defines the functional differences between message types.
    =================  =========================================  ================================
 
 .. note::
-   In addition of :term:`functional position`, the Excel version of the SXL
+   In addition to :term:`functional position`, the Excel version of the SXL
    can also differentiate between different kinds of command messages using
    :term:`maneuver` and :term:`parameter` sections. However, their use has no
    functional significance from a protocol point of view.
 
 Arguments and return values
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Argument and return values makes it possible to send extra information in
+Argument and return values make it possible to send extra information in
 messages. It is possible to send binary data (base64), such as bitmap
 pictures or other data, both to a site and to supervision system. The
 signal exchange list must clarify exactly which data type which is used
@@ -311,10 +290,10 @@ values is defined as extra columns for each row in the signal exchange
 list.
 
 - Arguments can be sent with command messages
-- Return values can be send with response on status requests or as extra
+- Return values can be sent with responses to status requests or as extra
   information with alarm messages
 
-The following table defines the message types which supports arguments and
+The following table defines the message types which support arguments and
 return values. 
 
 .. tabularcolumns:: |\Yl{0.20}|\Yl{0.20}|\Yl{0.20}|
@@ -330,3 +309,137 @@ return values.
    Commands           Yes       No
    =================  ========  ============
 
+.. _sxl-composition:
+
+SXL Composition
+---------------
+
+.. _sxl-prefixes:
+
+SXL Prefixes
+^^^^^^^^^^^^
+To ensure relevant SXLs can be used together, forward slashes should be used to
+organize component types and alarm, status, and command codes into hierarchies
+that avoid clashes.
+
+While it's often practical to use a prefix that relate to
+the SXL name, e.g. ``tlc/`` for a traffic light controller SLX , this is not a requirement.
+You have the freedom to organize types and codes as needed.
+
+For example, two SXLs with different names could both define types and codes under the same
+ prefix ``tlc/``, e.g. ``tlc/sg`` in one SXL and ``tlc/dl`` in the other.
+This ccan be useful in case you want to split a big SXL into smaller SXLs, while keeping the same prefix,
+or if you want to create an extension SXL that adds new types and codes under an existing prefix.
+
+Two SXLs can also define the exact same code. This means you cannot use them together, but it can be
+useful if you want to create a replacement SXL that is compatible with an existing SXL.
+
+To maintain backward compatibility, some existing SXLs might use codes without any forward slashes,
+e.g. a command code like ``M0001``. As long as you don't use another SXL with conflicting
+codes on the same site, this is not a problem.
+
+.. _sxl-message-types:
+.. _sxl-dependencies:
+
+SXL Dependencies
+^^^^^^^^^^^^^^^^
+An SXL can list other SXLs as dependencies.
+
+When an SXL depend on another SXL, it can rely on the definitions of component types and alarm,
+status and command codes the dependency.
+
+For example, let's assume that the ``traffic_light_controller`` SXL defines a ``tlc/sg`` component type.
+If the ``traffic_light_controller_advanced`` SXL depends
+on ``traffic_light_controller``, then it can define a command that operates on the ``tlc/sg`` type of component.
+
+Dependencies are listed using the SXL names and a version requirement. The order
+of dependencies is not significant.
+
+For example, a radar SXL might depend on a more basic sensor SXL like this:
+
+.. code-block:: yaml
+
+  dependencies:
+    sensor: "~1.3"
+
+Requirements support exact version, comparison operators ``>``, ``>=``, ``<``, ``<=`` and the compatibility operator ``~``.
+
+.. list-table:: Version requirement operators
+   :header: "Requirement", "Translation"
+
+   * - "1.3.1"
+     - exact version 1.3.1 only
+   * - ">=1.3.0"
+     - version 1.3.0 or higher
+   * - "<2.0.0"
+     - any version lower than 2.0.0
+   * - "~1.3"
+     - any version compatible with 1.3 according to semantic versioning rules, i.e. >=1.3.0 and <2.0.0.
+
+Two comparison operators can be combined with ``and``:
+
+.. list-table:: Version requirement combination
+   :header: "Requirement", "Translation"
+
+    * - ">=1.3.0 and <2.0.0"
+      - any version from 1.3.0 (inclusive) to 2.0.0 (exclusive)
+
+To ensure that dependency resolution works as intended, it's important to update
+the SXL version correctly when making changes to an SXL, according to Semantic
+Versioning (SemVer) rules.
+
+.. _sxl-processing:
+
+SXL Processing
+--------------
+
+.. _sxl-dependency_resolution:
+
+SXL Dependency Resolution
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Before SXLs can be loaded, dependencies must be resolved. 
+
+Dependency resolution must be performed whenever the set of SXLs used by a site changes.
+For a site with a static set of SXLs, this can be part of a compilation or configuration step.
+
+For sites that allow run-time changes to the set of SXLs, dependency resolution must be performed
+whenever SXLs are added, removed or updated.
+
+SXLs are resolved recursively using depth-first, in the order they are listed.
+Cyclic dependencies are not allowed and will cause dependency resolution to fail for the involved SXLs
+
+All SXLs that can be fully resolved are included in the resulting manifest.
+
+.. _sxl-manifest:
+
+SXL Manifest
+^^^^^^^^^^^^
+Dependency resolution results in an SXL manifest, which lists SXLs and their dependencies, and their exact versions.
+
+.. code-block:: yaml
+
+  manifest:
+    traffic_light_controller: 1.3.0
+    traffic_light_controller_advanced: 1.0.0
+    public_priority: 2.1.0
+
+A manifest must represent a valid set of SXLs, where all dependencies are met.
+
+.. _sxl-loading:
+
+SXL Loading
+^^^^^^^^^^^
+Before the SXLs in a manifest can be used they must be loaded.
+
+The SXLs listed in the manifest is loaded one by one, in the order they are listed, at the exact version
+specified.
+
+If the SXL is not available at the specified version, or cannot be fetched, loading of that SXL fails.
+
+Loading an SXL involves reading athe list of component types and alarms, status and command codes it defines, and adding it to a combined symbol table.
+
+Loading an SXL fails if a symbol with the same id has already been defined by a previously loaded SXL in the manifest, in which case
+none of the symbols from the SXL is added to the symbol table.
+
+After loading all SXLs in the manifest, the combined symbol table contains all component types and alarm,
+status and command codes available for use.

--- a/source/definitions.rst
+++ b/source/definitions.rst
@@ -11,6 +11,10 @@ Definitions
        The examples in this document are defined according to the following
        format: *Ayyyy*, where *yyyy* is a unique number.
 
+   Code id
+       A code id identifies alarms, commands and statuses. See :term:`Alarm code id`,
+       :term:`Command code id` and :term:`Status code id`.
+
    Command code id
        Identity of a command
 


### PR DESCRIPTION
Updates the sxl.rst file, to describe how multiple SXL are defined and referenced:

- id
- name
- version
- dependencies
- hierarchy
- code ids
- updated Version message that lists SXLs

There are some important concepts to consider here. It seems to me that we need a depency mechanism, so the version of an SXL you rely on is explicit.