### PR TITLE
Remove support for multiple sites on a single TLC connection

### DIFF
--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -110,8 +110,6 @@ messages, message acknowledgement messages and watchdog messages.
    ============ ================================================
    Element      Description
    ============ ================================================
-   ntsOId       :ref:`Component-id` for the :term:`NTS object`
-   xNId         :term:`External NTS id`
    cId          :ref:`Component-id`
    ============ ================================================
 

--- a/source/applicability/site_configuration.rst
+++ b/source/applicability/site_configuration.rst
@@ -76,14 +76,16 @@ Where:
 * ``ntsObjectId`` is the :ref:`Component-id` for the :term:`NTS object`
 * ``externalNtsId`` is the :term:`External NTS id`
 
-A component can either be categorized as a **single component** or **grouped
-component**, also known as the main component(s).
+A component can either be categorized as a **single component** or **main
+component**.
 
-The main component(s) is defined by **componentId** and **ntsObjectId** which are
-being set equal. This means that the component is visible from NTS.
+There can only be a single main component.
+
+The main component is defined by **componentId** and **ntsObjectId** which are
+being set equal.
 
 Single components have a unique **componentId** but uses the **ntsObjectId** of
-their main component.
+the main component.
 
 **externalNtsId** and **ntsObjectId** are optional and only used if the
 component is intended to be sent to :term:`NTS`.

--- a/source/applicability/site_configuration.rst
+++ b/source/applicability/site_configuration.rst
@@ -63,8 +63,6 @@ Using the YAML format, each component is defined like this:
         <component-type>:
           <component-1>:
             componentId: AA+BBCCC=DDDEEFFF
-            ntsObjectId: AA+BBCCC=DDDEEFFF
-            externalNtsId: 00000
 
 Where:
 
@@ -73,24 +71,7 @@ Where:
 * ``<component-type>`` defines which component type the component belongs to
 * ``<component-1>`` is the name of the component. For instance "signal group 1"
 * ``componentId`` is the :ref:`Component-id`
-* ``ntsObjectId`` is the :ref:`Component-id` for the :term:`NTS object`
-* ``externalNtsId`` is the :term:`External NTS id`
 
-A component can either be categorized as a **single component** or **main
-component**.
+The site must have exactly one main component.
 
-There can only be a single main component.
-
-The main component is defined by **componentId** and **ntsObjectId** which are
-being set equal.
-
-Single components have a unique **componentId** but uses the **ntsObjectId** of
-the main component.
-
-**externalNtsId** and **ntsObjectId** are optional and only used if the
-component is intended to be sent to :term:`NTS`.
-
-.. note::
-   :term:`NTS` is used at the Swedish Transport Administration. Other road
-   authorities typically leaves the `xNid` and `ntsOid` as empty strings.
 

--- a/source/definitions.rst
+++ b/source/definitions.rst
@@ -55,27 +55,12 @@ Definitions
 
        Designed to be used with NTS.
 
+    NTS
+       National Traffic management system at the Swedish Transport Administration
+
+
    NTS
       National Traffic management system at the Swedish Transport Administration
-
-   NTS object
-       Used for objects in :term:`NTS`
-
-       All control and supervision related functions in NTS consist of
-       NTS objects.
-
-       An NTS object can represent one or many components.
-
-   External NTS id
-       Identitiy for an :term:`NTS object` used in communication between NTS and other systems
-
-       The format is 5 integers and is unique for the site.
-       It is defined in cooperation with representatives from NTS.
-
-   NTS-Object type
-       A NTS object type is a classification of NTS objects.
-       Determines among other things which functional positions that
-       are possible for the NTS object.
 
    Component
        A :ref:`component <components>` represents physical or logical parts of a site,


### PR DESCRIPTION
This is done by only allowing a single main component in the SXL.

Discussion here: https://github.com/rsmp-nordic/rsmp_core/issues/251