### PR TITLE
Remove the component type definition

### DIFF
--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -127,7 +127,7 @@ This means you can define a new SXL that is compatible with an existing SXL, and
 
 Component Types
 ^^^^^^^^^^^^^^^
-An SXL defines the available :ref:`component` types. Components are the logical or physical part of a site.
+An SXL defines the available :term:`component` types. Components are the logical or physical part of a site.
 
 .. code-block:: yaml
 

--- a/source/definitions.rst
+++ b/source/definitions.rst
@@ -73,10 +73,6 @@ Definitions
        *Please note that a component is not necessarily the same thing as an
        NTS object.*
 
-   Component type
-       A :ref:`component-type` is used to classify :ref:`components`.
-       Component types are defined by SXLs.
-
    Component id
        A :ref:`component-id` identifies a :ref:`component <components>`.
 


### PR DESCRIPTION
Remove "component type" from the definitions.rst.
It's already defined in sxl.rst.