### PR TITLE
Remove duplicate "NTS" definition

### DIFF
--- a/source/definitions.rst
+++ b/source/definitions.rst
@@ -59,10 +59,6 @@ Definitions
 
        Designed to be used with NTS.
 
-    NTS
-       National Traffic management system at the Swedish Transport Administration
-
-
    NTS
       National Traffic management system at the Swedish Transport Administration
 


### PR DESCRIPTION
This was introduced in bac5fd93f1743aefd8e974b929401d31cd6ba355 by mistake.

Original issue: https://github.com/rsmp-nordic/rsmp_core/issues/284