### PR TITLE
Add missing ComponentList in connection sequence

### DIFF
--- a/source/img/msc/establish-site-system.msc
+++ b/source/img/msc/establish-site-system.msc
@@ -19,6 +19,8 @@ msc {
   |||;
   a<=b [ label = "Watchdog" ];
   |||;
+  a=>b [ label = "ComponentList" ];
+  |||;
   --- [ label = "Asynchronous message exchange can begin" ];
   |||;
   a=>b [ label = "Aggregated status" ];


### PR DESCRIPTION
The message type "ComponentList" was added with https://github.com/rsmp-nordic/rsmp_core/pull/267, but the connection sequence diagram between site and system was never updated  to match the text.