### PR TITLE
Add ComponentList for use in connection sequence between sites

### DIFF
--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -239,12 +239,14 @@ implicit in the following figure.
 
 7. The leader site sends Watchdog (according to section :ref:`watchdog`)
 
-8. Asynchronous message exchange can begin. This means that commands and
+8. The follower site sends a ComponentList message (according to section :ref:`component-list`).
+
+9. Asynchronous message exchange can begin. This means that commands and
    statuses are allowed to be sent
 
-9. Aggregated status (according to section :ref:`aggregated-status-message`)
-   If no component for aggregated status is defined in the signal exchange list
-   then no aggregated status message is sent.
+10. Aggregated status (according to section :ref:`aggregated-status-message`)
+    If no component for aggregated status is defined in the signal exchange list
+    then no aggregated status message is sent.
 
 For communication between sites the following applies:
 

--- a/source/img/msc/establish-site-site.msc
+++ b/source/img/msc/establish-site-site.msc
@@ -19,6 +19,8 @@ msc {
   |||;
   a<=b [ label = "Watchdog" ];
   |||;
+  a=>b [ label = "ComponentList" ];
+  |||;
   --- [ label = "Asynchronous message exchange can begin" ];
   |||;
   a=>b [ label = "Aggregated status" ];


### PR DESCRIPTION
With the PR https://github.com/rsmp-nordic/rsmp_core/pull/267, the ComponentList was added in the connection establishment between site and system.

However, it should be added in the connection establishment between sites as well. It only needs to be sent from the one of the sites, (the follower), since that's the only SXL that is used in site-site communication.