### PR TITLE
Remove Datex definition

### DIFF
--- a/source/definitions.rst
+++ b/source/definitions.rst
@@ -29,10 +29,6 @@ Definitions
    External NTS alarm code id
        Alarm code in order to identify alarm type during communication with NTS
 
-   DATEX II
-       European standard for message exchange between traffic systems
-       (www.datex2.eu)
-
    Functional position
        Provides command options for a site. For instance, "start" or "stop"
        It is meant to be used for the entire site and not for an individual


### PR DESCRIPTION
There are no mentions of Datex elsewhere in the spec. The definition should probably have been removed with https://github.com/rsmp-nordic/rsmp_core/pull/209, but was left behind.