### PR TITLE
Sus schema tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+group :development do
+  gem 'json_schemer', '~> 2.5'
+  gem 'sus', '~> 0.36'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bigdecimal (4.1.2)
+    hana (1.3.7)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
+    regexp_parser (2.12.0)
+    simpleidn (0.2.3)
+    sus (0.36.0)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-22
+
+DEPENDENCIES
+  json_schemer (~> 2.5)
+  sus (~> 0.36)
+
+CHECKSUMS
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
+  json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
+  sus (0.36.0) sha256=5e1828908cab1ccb1dffcf2d14dfb72e2089a0cd77ee979eee6d61beaaa3722f
+
+BUNDLED WITH
+  4.0.9

--- a/schema/aggregated_status.json
+++ b/schema/aggregated_status.json
@@ -1,0 +1,25 @@
+{
+  "title" :  "Aggregated Status",
+  "description" :  "Aggregated status message",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "aSTS" : { "$ref": "definitions.json#/timestamp" },
+    "fP" : {
+      "description" : "Functional position",
+      "type" : "string, null"
+    },
+    "fS" : {
+      "description" : "Functional position",
+      "type" : "string, null"
+    },
+    "se" : {
+      "type" : "array",
+      "minItems": 8,
+      "maxItems": 8,
+      "items" : {
+        "type" : "boolean"
+      }
+    }
+  },
+  "required" : [ "mId", "aSTS", "fP", "fS", "se" ]
+}

--- a/schema/aggregated_status.json
+++ b/schema/aggregated_status.json
@@ -6,11 +6,11 @@
     "aSTS" : { "$ref": "definitions.json#/timestamp" },
     "fP" : {
       "description" : "Functional position",
-      "type" : "string, null"
+      "type" : ["string", "null"]
     },
     "fS" : {
       "description" : "Functional position",
-      "type" : "string, null"
+      "type" : ["string", "null"]
     },
     "se" : {
       "type" : "array",

--- a/schema/aggregated_status_request.json
+++ b/schema/aggregated_status_request.json
@@ -1,0 +1,9 @@
+{
+  "title" :  "Aggregated Status Request",
+  "description" :  "Aggregated status request message",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "cId" : { "$ref": "definitions.json#/component_id" }
+  },
+  "required" : [ "mId", "cId" ]
+}

--- a/schema/alarm.json
+++ b/schema/alarm.json
@@ -1,0 +1,71 @@
+{
+  "title" :  "Alarm",
+  "description" :  "Alarm messsage",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "cId" : { "$ref": "definitions.json#/component_id" },
+    "aCId" : { "$ref": "definitions.json#/alarm_code" },
+    "xACId" : { "description" : "External alarm code id", "type" : "string" },
+    "aSp" : {
+      "description" : "Alarm specialization",
+      "type" : "string",
+      "enum" : [ "Issue", "Acknowledge", "Suspend", "Resume", "Request" ]
+    }
+  },
+  "required" : [ "aSp"],
+  "allOf" : [
+    {
+      "if": {
+        "required" : [ "aSp" ],
+        "properties" : {
+          "aSp" : { "enum" : [ "Issue"] }
+        }
+      },
+      "then": { "$ref": "alarm_issue.json" }
+    },
+    {
+      "if": {
+        "allOf" : [
+          {
+            "required" : [ "aSp" ],
+            "properties" : {
+              "aSp" : { "enum" : [ "Suspend", "Resume"] }
+            }
+          },
+          {
+            "not": { "required" : [ "sS" ] }
+          }
+        ]
+      },
+      "then": { "$ref": "alarm_suspend_resume.json" }
+    },
+    {
+      "if": {
+        "required" : [ "aSp", "sS" ],
+        "properties" : {
+          "aSp" : { "enum" : [ "Suspend", "Resume"] },
+          "sS" : { "enum" : [ "Suspended", "notSuspended"] }
+        }
+      },
+      "then": { "$ref": "alarm_suspended_resumed.json" }
+    },
+    {
+      "if": {
+        "required" : [ "aSp" ],
+        "properties" : {
+          "aSp" : { "enum" : [ "Request"] }
+        }
+      },
+      "then": { "$ref": "alarm_request.json" }
+    },
+    {
+      "if": {
+        "required" : [ "aSp" ],
+        "properties" : {
+          "aSp" : { "enum" : [ "Acknowledge"] }
+        }
+      },
+      "then": { "$ref": "alarm_acknowledge.json" }
+    }
+   ]
+}

--- a/schema/alarm_acknowledge.json
+++ b/schema/alarm_acknowledge.json
@@ -1,0 +1,11 @@
+{
+  "properties" : {
+    "ack" : {
+      "description" : "Acknowledgement",
+      "type" : "string",
+      "enum" : [ "Acknowledged", "notAcknowledged" ]
+    },
+    "aTs" : { "$ref": "definitions.json#/timestamp" }
+  },
+  "required" : [ "mId", "cId", "aCId", "xACId", "aSp", "aTs" ]
+}

--- a/schema/alarm_issue.json
+++ b/schema/alarm_issue.json
@@ -1,0 +1,44 @@
+{
+  "properties" : {
+    "ack" : {
+      "description" : "Acknowledgement",
+      "type" : "string",
+      "enum" : [ "Acknowledged", "notAcknowledged" ]
+    },
+    "aS" : {
+      "description" : "Active status",
+      "type" : "string",
+      "enum" : [ "inActive", "Active" ]
+    },
+    "sS" : {
+      "description" : "Suspend status",
+      "type" : "string",
+      "enum" : [ "suspended", "notSuspended" ]
+    },
+    "aTs" : { "$ref": "definitions.json#/timestamp" },
+    "cat" : {
+      "description" : "Category",
+      "type" : "string",
+      "enum" : [ "T", "D" ]
+    },
+    "pri" : {
+      "description" : "Priority",
+      "type" : "string",
+      "enum" : [ "1", "2", "3" ]
+    },
+    "rvs" : {
+      "description" : "Return values",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties": {
+          "n" : { "description" : "Unique reference of the value", "type" : "string" },
+          "v" : { "description" : "Value", "type" : "string" }
+        },
+        "required" : [ "n", "v" ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required" : [ "mId", "cId", "aCId", "xACId", "aSp", "ack", "aS", "aTs", "sS", "cat", "pri", "rvs" ]
+}

--- a/schema/alarm_request.json
+++ b/schema/alarm_request.json
@@ -1,0 +1,3 @@
+{
+  "required" : [ "mId", "cId", "aCId", "xACId", "aSp" ]
+}

--- a/schema/alarm_suspend_resume.json
+++ b/schema/alarm_suspend_resume.json
@@ -1,0 +1,3 @@
+{
+  "required" : [ "mId", "cId", "aCId", "xACId", "aSp" ]
+}

--- a/schema/alarm_suspended_resumed.json
+++ b/schema/alarm_suspended_resumed.json
@@ -1,0 +1,44 @@
+{
+  "properties" : {
+    "ack" : {
+      "description" : "Acknowledgement",
+      "type" : "string",
+      "enum" : [ "Acknowledged", "notAcknowledged" ]
+    },
+    "aS" : {
+      "description" : "Active status",
+      "type" : "string",
+      "enum" : [ "inActive", "Active" ]
+    },
+    "sS" : {
+      "description" : "Suspend status",
+      "type" : "string",
+      "enum" : [ "Suspended", "notSuspended" ]
+    },
+    "aTs" : { "$ref": "definitions.json#/timestamp" },
+    "cat" : {
+      "description" : "Category",
+      "type" : "string",
+      "enum" : [ "T", "D" ]
+    },
+    "pri" : {
+      "description" : "Priority",
+      "type" : "string",
+      "enum" : [ "1", "2", "3" ]
+    },
+    "rvs" : {
+      "description" : "Return values",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties": {
+          "n" : { "description" : "Unique reference of the value", "type" : "string" },
+          "v" : { "description" : "Value", "type" : "string" }
+        },
+        "required" : [ "n", "v" ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required" : [ "mId", "cId", "aCId", "xACId", "aSp", "ack", "aS", "aTs", "sS", "cat", "pri", "rvs" ]
+}

--- a/schema/command_request.json
+++ b/schema/command_request.json
@@ -1,0 +1,24 @@
+{
+  "title" :  "CommandRequest",
+  "description" :  "Command request",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "cId" : { "$ref": "definitions.json#/component_id" },
+    "arg" : {
+      "description" : "Command arguments",
+      "type" : "array",
+      "minItems": 1,
+      "items" : {
+        "type" : "object",
+        "properties": {
+          "cCI" : { "$ref": "definitions.json#/command_code" },
+          "n" : { "description" : "Unique reference of the value", "type" : "string" },
+          "cO" : { "description" : "Command", "type" : "string" },
+          "v" : { "description" : "Value" }
+        },
+        "required" : [ "cCI", "n", "cO", "v" ]
+      }
+    }
+  },
+  "required" : [ "mId", "cId", "arg"]
+}

--- a/schema/command_response.json
+++ b/schema/command_response.json
@@ -1,0 +1,34 @@
+{
+  "title" :  "CommandRequest",
+  "description" :  "Command request",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "cId" : { "$ref": "definitions.json#/component_id" },
+    "cTS" : { "$ref": "definitions.json#/timestamp" },
+    "rvs" : {
+      "description" : "Command arguments",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties": {
+          "cCI" : { "$ref": "definitions.json#/command_code" },
+          "n" : {
+            "description" : "Unique reference of the value",
+            "type" : "string"
+          },
+          "v" : {
+            "description" : "Value"
+          },
+          "age" : {
+            "description" : "Age of the value",
+            "type" : "string",
+            "enum" : [ "recent", "old", "undefined", "unknown" ]
+          }
+        },
+        "required" : [ "cCI", "n", "v", "age" ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required" : [ "mId", "cId", "cTS", "rvs" ]
+}

--- a/schema/command_response.json
+++ b/schema/command_response.json
@@ -8,6 +8,7 @@
     "rvs" : {
       "description" : "Command arguments",
       "type" : "array",
+      "minItems" : 1,
       "items" : {
         "type" : "object",
         "properties": {

--- a/schema/core.json
+++ b/schema/core.json
@@ -1,0 +1,39 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "name" : "core",
+  "description" : "Core",
+  "version" : "3.2.0",
+  "type" :  "object",
+  "allOf" : [
+    {
+      "properties" : {
+        "mType" : {
+          "description" : "Supported RSMP versions",
+          "type" : "string",
+          "const" : "rSMsg"
+        },
+        "type" : {
+          "description" : "Type of RMSP message",
+          "type" : "string",
+          "enum" : [
+            "MessageAck",
+            "MessageNotAck",
+            "Version",
+            "AggregatedStatus",
+            "AggregatedStatusRequest",
+            "Watchdog",
+            "Alarm",
+            "CommandRequest",
+            "CommandResponse",
+            "StatusRequest",
+            "StatusResponse",
+            "StatusSubscribe",
+            "StatusUnsubscribe",
+            "StatusUpdate"
+          ]
+        }
+      },
+      "required" : [ "mType", "type" ]
+    }
+  ]
+}

--- a/schema/core.json
+++ b/schema/core.json
@@ -2,7 +2,7 @@
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "name" : "core",
   "description" : "Core",
-  "version" : "3.2.0",
+  "version" : "3.3.0",
   "type" :  "object",
   "allOf" : [
     {

--- a/schema/core.json
+++ b/schema/core.json
@@ -1,5 +1,5 @@
 {
-  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
   "name" : "core",
   "description" : "Core",
   "version" : "3.3.0",

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -1,0 +1,67 @@
+{
+  "message_id": {
+    "description" : "Message Id",
+    "type": "string",
+    "$comment" : "Example: 1.2.3 or 1.2",
+    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
+  },
+  "timestamp" : {
+    "description" : "Timestamp",
+    "type": "string",
+    "$comment" : "Example: 2015-06-08T11:49:03.293Z",
+    "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$"
+  },
+  "integer" : {
+    "description" : "Integer as string",
+    "type": "string",
+    "$comment" : "Example: 123 or -123",
+    "pattern": "^\\-?[0-9]+$"
+  },
+  "version": {
+    "description" : "Version",
+    "type": "string",
+    "$comment" : "Example: 1.2.3 or 1.2",
+    "pattern" : "^[0-9]{1,2}\\.[0-9]{1,2}(\\.[0-9]{1,2})?"
+  },
+  "command_code": {
+    "description" : "Command code id",
+    "type" : "string",
+    "pattern" : "^M"
+  },
+  "status_code": {
+    "description" : "Status code id",
+    "type" : "string",
+    "pattern" : "^S"
+  },
+  "alarm_code": {
+    "description" : "Alarm code id",
+    "type" : "string",
+    "pattern" : "^A"
+  },
+  "component_id": {
+    "description" : "Compoment id",
+    "type" : "string"
+  },
+  "boolean": {
+    "description" : "Boolean as string",
+    "type" : "string",
+    "enum" : [ "True", "False" ]
+  },
+  "integer_list": {
+    "description" : "Comma-separated list of integers as strings",
+    "type" : "string",
+    "pattern" : "^(\\-?\\d+)(?:,(\\-?\\d+))*$"
+  },
+  "boolean_list": {
+    "description" : "Comma-separated list of booleans as strings",
+    "type" : "string",
+    "pattern" : "^(True|False)(?:,(True|False))*$"
+  },
+  "string_list": {
+    "description" : "Comma-separated list of strings",
+    "type" : "string"
+  }
+}
+
+
+

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -52,6 +52,11 @@
     "type" : "string",
     "pattern" : "^(\\-?\\d+)(?:,(\\-?\\d+))*$"
   },
+  "number_list": {
+    "description" : "Comma-separated list of numbers as strings",
+    "type" : "string",
+    "pattern" : "^(\\-?\\d+(\\.\\d+)?)(?:,(\\-?\\d+(\\.\\d+)?))*$"
+  },
   "boolean_list": {
     "description" : "Comma-separated list of booleans as strings",
     "type" : "string",

--- a/schema/message_ack.json
+++ b/schema/message_ack.json
@@ -1,0 +1,11 @@
+{
+  "title" :  "MessageAck",
+  "description" :  "Message acknowledged",
+  "properties" : {
+    "oMId" : {
+      "$ref": "definitions.json#/message_id",
+      "description" : "Old message id"
+    }
+  },
+  "required" : [ "oMId" ]
+}

--- a/schema/message_not_ack.json
+++ b/schema/message_not_ack.json
@@ -1,0 +1,15 @@
+{
+  "title" :  "MessageNotAck",
+  "description" :  "Message not acknowledgeded",
+  "properties" : {
+    "oMId" : {
+      "$ref": "definitions.json#/message_id",
+      "description" : "Old message id"
+    },
+    "rea" : {
+      "description" : "Reason / Error message",
+      "type" : "string"
+    }
+  },
+  "required" : [ "oMId" ]
+}

--- a/schema/rsmp.json
+++ b/schema/rsmp.json
@@ -1,0 +1,133 @@
+{
+  "allOf": [
+    {
+      "$ref": "core.json"
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "MessageAck" } }
+      },
+      "then": {
+        "$ref": "message_ack.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "MessageNotAck" } }
+      },
+      "then": {
+        "$ref": "message_not_ack.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "Version" } }
+      },
+      "then": {
+        "$ref": "version.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "AggregatedStatus" } }
+      },
+      "then": {
+        "$ref": "aggregated_status.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "AggregatedStatusRequest" } }
+      },
+      "then": {
+        "$ref": "aggregated_status_request.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "Watchdog" } }
+      },
+      "then": {
+        "$ref": "watchdog.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "Alarm" } }
+      },
+      "then": {
+        "$ref": "alarm.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "CommandRequest" } }
+      },
+      "then": {
+        "$ref": "command_request.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "CommandResponse" } }
+      },
+      "then": {
+        "$ref": "command_response.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "StatusRequest" } }
+      },
+      "then": {
+        "$ref": "status_request.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "StatusResponse" } }
+      },
+      "then": {
+        "$ref": "status_response.json"
+      }
+    },
+    {
+      "if": {
+         "required" : ["type"],
+       "properties": { "type": { "const": "StatusSubscribe" } }
+      },
+      "then": {
+        "$ref": "status_subscribe.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "StatusUnsubscribe" } }
+      },
+      "then": {
+        "$ref": "status_unsubscribe.json"
+      }
+    },
+    {
+      "if": {
+        "required" : ["type"],
+        "properties": { "type": { "const": "StatusUpdate" } }
+      },
+      "then": {
+        "$ref": "status_update.json"
+      }
+    }
+  ]
+}

--- a/schema/status.json
+++ b/schema/status.json
@@ -1,0 +1,21 @@
+{
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "cId" : { "$ref": "definitions.json#/component_id" },
+    "sS" : {
+      "description" : "Status request arguments",
+      "type" : "array",
+      "minItems": 1,
+      "items" : {
+        "type" : "object",
+        "properties": {
+          "sCI" : { "$ref": "definitions.json#/status_code" },
+          "n" : { "description" : "Unique reference of the value", "type" : "string" }
+        },
+        "required" : [ "sCI", "n" ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required" : [ "mId", "cId", "sS"]
+}

--- a/schema/status_request.json
+++ b/schema/status_request.json
@@ -1,0 +1,5 @@
+{
+  "title" :  "StatusRequest",
+  "description" :  "Status request",
+  "$ref": "status.json"
+}

--- a/schema/status_response.json
+++ b/schema/status_response.json
@@ -1,0 +1,41 @@
+{
+  "title" :  "StatusResponse",
+  "description" :  "Status response",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "cId" : { "$ref": "definitions.json#/component_id" },
+    "sTs" : { "$ref": "definitions.json#/timestamp" },
+    "sS" : {
+      "description" : "Status response arguments",
+      "type" : "array",
+      "minItems": 1,
+      "items" : {
+        "type" : "object",
+        "properties": {
+          "sCI" : { "$ref": "definitions.json#/status_code" },
+          "n" : { "description" : "Unique reference of the value", "type" : "string" },
+          "s" : { "description" : "Value"},
+          "q" : { "description" : "Quality", "type" : "string", "enum" : [ "recent", "old", "undefined", "unknown"] }
+        },
+        "if": {
+          "properties": {
+            "q" : { "enum" : ["unknown","undefined"] }
+          }
+        },
+        "then": {
+          "properties": {
+            "s" : { "type" : "null" }
+          }
+        },
+        "else": {
+          "properties": {
+            "s" : { "type" : ["string","array"] }
+          }
+        },
+        "required" : [ "sCI", "n", "s", "q" ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required" : [ "mId", "cId", "sTs", "sS" ]
+}

--- a/schema/status_subscribe.json
+++ b/schema/status_subscribe.json
@@ -1,0 +1,31 @@
+{
+  "title" :  "StatusSubscribe",
+  "description" :  "Status subscribe",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "cId" : { "$ref": "definitions.json#/component_id" },
+    "sS" : {
+      "description" : "Status request arguments",
+      "type" : "array",
+      "minItems": 1,
+      "items" : {
+        "type" : "object",
+        "properties": {
+          "sCI" : { "$ref": "definitions.json#/status_code" },
+          "n" : { "description" : "Unique reference of the value", "type" : "string" },
+          "uRt" : {
+            "$ref": "definitions.json#/integer",
+            "description" : "Update interval in seconds, 0 means send when value changes"
+          },
+          "sOc" : {
+            "type": "boolean",
+            "description" : "Whether to send an update as soon as the value changes"
+          }
+        },
+        "required" : [ "sCI", "n", "uRt", "sOc" ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required" : [ "mId", "cId", "sS"]
+}

--- a/schema/status_unsubscribe.json
+++ b/schema/status_unsubscribe.json
@@ -1,0 +1,5 @@
+{
+  "title" :  "StatusUnsubscribe",
+  "description" :  "Status unsubscribe",
+  "$ref": "status.json"
+}

--- a/schema/status_update.json
+++ b/schema/status_update.json
@@ -1,0 +1,41 @@
+ {
+  "title" :  "StatusUpdate",
+  "description" :  "Status update",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "cId" : { "$ref": "definitions.json#/component_id" },
+    "sTs" : { "$ref": "definitions.json#/timestamp" },
+    "sS" : {
+      "description" : "Status update arguments",
+      "type" : "array",
+      "minItems": 1,
+      "items" : {
+        "type" : "object",
+        "properties": {
+          "sCI" : { "$ref": "definitions.json#/status_code" },
+          "n" : { "description" : "Unique reference of the value", "type" : "string" },
+          "s" : { "description" : "Value"},
+          "q" : { "description" : "Quality", "type" : "string", "enum" : [ "recent", "old", "undefined", "unknown"] }
+        },
+        "if": {
+          "properties": {
+            "q" : { "enum" : ["unknown","undefined"] }
+          }
+        },
+        "then": {
+          "properties": {
+            "s" : { "type" : "null" }
+          }
+        },
+        "else": {
+          "properties": {
+            "s" : { "type" : ["string","array"] }
+          }
+        },
+        "required" : [ "sCI", "n", "s", "q" ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required" : [ "mId", "cId", "sTs", "sS" ]
+}

--- a/schema/version.json
+++ b/schema/version.json
@@ -1,0 +1,47 @@
+{
+  "title" :  "Version",
+  "description" :  "Version message",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "RSMP" : {
+      "description" : "Supported RSMP versions",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "vers" : {
+            "$ref": "definitions.json#/version",
+            "description" : "RSMP version"
+          }
+        },
+        "required" : ["vers"],
+        "additionalProperties" : false
+      },
+      "minItems" : 1,
+      "uniqueItems" : true
+    },
+    "SXL" : {
+      "$ref": "definitions.json#/version",
+      "description" : "SXL version"
+    },
+    "siteId" : {
+      "description" : "Site ids",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "sId" : {
+            "type" : "string",
+            "minLength": 1
+          }
+        },
+        "required" : [ "sId" ],
+        "additionalProperties" : false
+      },
+      "minItems" : 1,
+      "uniqueItems" : true,
+      "additionalProperties" : false
+    }
+  },
+  "required" : [ "mId", "RSMP", "SXL", "siteId" ]
+}

--- a/schema/watchdog.json
+++ b/schema/watchdog.json
@@ -1,0 +1,9 @@
+{
+  "title" :  "Watchdog",
+  "description" :  "Watchdog message",
+  "properties" : {
+    "mId" : { "$ref": "definitions.json#/message_id" },
+    "wTs" : { "$ref": "definitions.json#/timestamp" }
+  },
+  "required" : [ "mId", "wTs" ]
+}

--- a/test/schema/aggregated_status.rb
+++ b/test/schema/aggregated_status.rb
@@ -1,0 +1,77 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'AggregatedStatus' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "type" => "AggregatedStatus",
+    "mId" => "be12ab9a-800c-4c19-8c50-adf832f22420",
+    "cId" => "O+14439=481WA001",
+    "aSTS" => "2015-06-08T08:05:06.584Z",
+    "fP" => nil,
+    "fS" => nil,
+    "se" => [true, false, false, false, false, false, false, false]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing mId' do
+    message.delete 'mId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["mId"]}]]
+    )
+  end
+
+  it 'catches missing aSTS' do
+    message.delete 'aSTS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["aSTS"]}]]
+    )
+  end
+
+  it 'catches bad aSTS' do
+    message['aSTS'] = "2015-06-08T08:05:06.5843Z"
+    expect( validate(message) ).to be == (
+      [["/aSTS", "pattern"]]
+    )
+  end
+
+  it 'catches missing se' do
+    message.delete 'se'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["se"]}]]
+    )
+  end
+
+  it 'catches bad se type' do
+    message['se'] = 123
+    expect( validate(message) ).to be == (
+      [["/se", "array"]]
+    )
+  end
+
+  it 'catches se too short' do
+    message['se'] = [true, false, false, false, false, false, false]
+    expect( validate(message) ).to be == (
+      [["/se", "minItems"]]
+    )
+  end
+
+  it 'catches se too long' do
+    message['se'] = [true, false, false, false, false, false, false, true, true]
+    expect( validate(message) ).to be == (
+      [["/se", "maxItems"]]
+    )
+  end
+
+  it 'catches bad se item types' do
+    message['se'] = [false, false, false, 1, nil, "", false, false]
+    expect( validate(message) ).to be == (
+      [["/se/3", "boolean"],
+       ["/se/4", "boolean"],
+       ["/se/5", "boolean"]]
+    )
+  end
+end

--- a/test/schema/aggregated_status_request.rb
+++ b/test/schema/aggregated_status_request.rb
@@ -1,0 +1,22 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'AggregatedStatusRequest' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "type" => "AggregatedStatusRequest",
+    "mId" => "be12ab9a-800c-4c19-8c50-adf832f22420",
+    "cId" => "O+14439=481WA001"
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing mId' do
+    message.delete 'mId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["mId"]}]]
+    )
+  end
+end

--- a/test/schema/alarm_acknowledge.rb
+++ b/test/schema/alarm_acknowledge.rb
@@ -1,0 +1,89 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'Alarm Acknowledge' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "type" => "Alarm",
+    "mId" => "E68A0010-C336-41ac-BD58-5C80A72C7092",
+    "cId" => "AB+84001=860SG001",
+    "aCId" => "A0001",
+    "xACId" => "",
+    "aSp" => "Acknowledge",
+    "aTs" => "2009-10-01T11:59:31.571Z"
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'rejects lowercase aSp' do
+    message["aSp"] = 'acknowledge'
+    expect( validate(message) ).to be == (
+      [["/aSp", "enum"]]
+    )
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches missing alarm code id' do
+    message.delete 'aCId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["aCId"]}]]
+    )
+  end
+
+  it 'catches bad alarm code id' do
+    message['aCId'] = "001"
+    expect( validate(message) ).to be == (
+      [["/aCId", "pattern"]]
+    )
+  end
+
+  it 'catches wrong alarm code id type' do
+    message['aCId'] = 123
+    expect( validate(message) ).to be == (
+      [["/aCId", "string"]]
+    )
+  end
+
+  it 'catches missing extended alarm code id' do
+    message.delete 'xACId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["xACId"]}]]
+    )
+  end
+
+  it 'catches wrong extended alarm code id type' do
+    message['xACId'] = 123
+    expect( validate(message) ).to be == (
+      [["/xACId", "string"]]
+    )
+  end
+
+  it 'catches missing timestamp' do
+    message.delete 'aTs'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["aTs"]}]]
+    )
+  end
+
+  it 'catches bad timestamp' do
+    message['aTs'] = "yesterday"
+    expect( validate(message) ).to be == (
+      [["/aTs", "pattern"]]
+    )
+  end
+
+  it 'catches wrong timestamp type' do
+    message['aTs'] = 123
+    expect( validate(message) ).to be == (
+      [["/aTs", "string"]]
+    )
+  end
+end

--- a/test/schema/alarm_issue.rb
+++ b/test/schema/alarm_issue.rb
@@ -1,0 +1,287 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'Alarm Issue' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "type" => "Alarm",
+    "mId" => "E68A0010-C336-41ac-BD58-5C80A72C7092",
+    "cId" => "AB+84001=860SG001",
+    "aCId" => "A0001",
+    "xACId" => "Serious lamp error",
+    "aSp" => "Issue",
+    "ack" => "notAcknowledged",
+    "aS" => "Active",
+    "sS" => "notSuspended",
+    "aTs" => "2009-10-01T11:59:31.571Z",
+    "cat" => "D",
+    "pri" => "2",
+    "rvs" => [
+      { "n" => "color", "v" => "red" }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'rejects lowercase aSp' do
+    message["aSp"] = 'issue'
+    expect( validate(message) ).to be == (
+      [["/aSp", "enum"]]
+    )
+  end
+
+  it 'rejects lowercase aS variants' do
+    ["active", "inactive", "InActive"].each do |status|
+      message["aS"] = status
+      expect( validate(message) ).to be == (
+        [["/aS", "enum"]]
+      )
+    end
+  end
+
+  it 'rejects mixed-case ack' do
+    message["ack"] = 'NotAcknowledged'
+    expect( validate(message) ).to be == (
+      [["/ack", "enum"]]
+    )
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches missing alarm code id' do
+    message.delete 'aCId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["aCId"]}]]
+    )
+  end
+
+  it 'catches bad alarm code id' do
+    message['aCId'] = "001"
+    expect( validate(message) ).to be == (
+      [["/aCId", "pattern"]]
+    )
+  end
+
+  it 'catches wrong alarm code id type' do
+    message['aCId'] = 123
+    expect( validate(message) ).to be == (
+      [["/aCId", "string"]]
+    )
+  end
+
+  it 'catches missing extended alarm code id' do
+    message.delete 'xACId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["xACId"]}]]
+    )
+  end
+
+  it 'catches wrong extended alarm code id type' do
+    message['xACId'] = 123
+    expect( validate(message) ).to be == (
+      [["/xACId", "string"]]
+    )
+  end
+
+  it 'catches missing aSp' do
+    message.delete 'aSp'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["aSp"]}]]
+    )
+  end
+
+  it 'catches bad aSp' do
+    message['aSp'] = "Bad"
+    expect( validate(message) ).to be == (
+      [["/aSp", "enum"]]
+    )
+  end
+
+  it 'catches wrong aSp type' do
+    message['aSp'] = 123
+    expect( validate(message) ).to be == (
+      [["/aSp", "string"],
+       ["/aSp", "enum"]]
+    )
+  end
+
+  it 'catches missing aS' do
+    message.delete 'aS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["aS"]}]]
+    )
+  end
+
+  it 'catches bad aS' do
+    message['aS'] = "Bad"
+    expect( validate(message) ).to be == (
+      [["/aS", "enum"]]
+    )
+  end
+
+  it 'catches wrong aS type' do
+    message['aS'] = 123
+    expect( validate(message) ).to be == (
+      [["/aS", "string"],
+       ["/aS", "enum"]]
+    )
+  end
+
+  it 'catches missing sS' do
+    message.delete 'sS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["sS"]}]]
+    )
+  end
+
+  it 'catches bad sS' do
+    message['sS'] = "Bad"
+    expect( validate(message) ).to be == (
+      [["/sS", "enum"]]
+    )
+  end
+
+  it 'catches wrong sS type' do
+    message['sS'] = 123
+    expect( validate(message) ).to be == (
+      [["/sS", "string"],
+       ["/sS", "enum"]]
+    )
+  end
+
+  it 'catches missing ack' do
+    message.delete 'ack'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["ack"]}]]
+    )
+  end
+
+  it 'catches bad ack' do
+    message['ack'] = "Bad"
+    expect( validate(message) ).to be == (
+      [["/ack", "enum"]]
+    )
+  end
+
+  it 'catches wrong ack type' do
+    message['ack'] = 123
+    expect( validate(message) ).to be == (
+      [["/ack", "string"],
+       ["/ack", "enum"]]
+    )
+  end
+
+  it 'catches missing category' do
+    message.delete 'cat'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cat"]}]]
+    )
+  end
+
+  it 'catches bad category' do
+    message['cat'] = "A"
+    expect( validate(message) ).to be == (
+      [["/cat", "enum"]]
+    )
+  end
+
+  it 'catches wrong category type' do
+    message['cat'] = 123
+    expect( validate(message) ).to be == (
+      [["/cat", "string"],
+       ["/cat", "enum"]]
+    )
+  end
+
+  it 'catches missing priority' do
+    message.delete 'pri'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["pri"]}]]
+    )
+  end
+
+  it 'catches bad priority' do
+    message['pri'] = "4"
+    expect( validate(message) ).to be == (
+      [["/pri", "enum"]]
+    )
+  end
+
+  it 'catches wrong priority type' do
+    message['pri'] = 1
+    expect( validate(message) ).to be == (
+      [["/pri", "string"],
+       ["/pri", "enum"]]
+    )
+  end
+
+  it 'catches missing timestamp' do
+    message.delete 'aTs'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["aTs"]}]]
+    )
+  end
+
+  it 'catches bad timestamp' do
+    message['aTs'] = "yesterday"
+    expect( validate(message) ).to be == (
+      [["/aTs", "pattern"]]
+    )
+  end
+
+  it 'catches wrong timestamp type' do
+    message['aTs'] = 123
+    expect( validate(message) ).to be == (
+      [["/aTs", "string"]]
+    )
+  end
+
+  it 'catches missing rvs' do
+    message.delete 'rvs'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["rvs"]}]]
+    )
+  end
+
+  it 'catches bad rvs type' do
+    message["rvs"] = {}
+    expect( validate(message) ).to be == (
+      [["/rvs", "array"]]
+    )
+  end
+
+  it 'catches missing alarm return value name' do
+    message["rvs"].first.delete 'n'
+    expect( validate(message) ).to be == (
+      [["/rvs/0", "required", {"missing_keys"=>["n"]}]]
+    )
+  end
+
+  it 'catches bad alarm return value name' do
+    message["rvs"].first['n'] = 3
+    expect( validate(message) ).to be == (
+      [["/rvs/0/n", "string"]]
+    )
+  end
+
+  it 'catches missing alarm return value' do
+    message["rvs"].first.delete 'v'
+    expect( validate(message) ).to be == (
+      [["/rvs/0", "required", {"missing_keys"=>["v"]}]]
+    )
+  end
+
+  it 'catches bad alarm return value' do
+    message["rvs"].first['v'] = 3
+    expect( validate(message) ).to be == (
+      [["/rvs/0/v", "string"]]
+    )
+  end
+end

--- a/test/schema/alarm_request.rb
+++ b/test/schema/alarm_request.rb
@@ -1,0 +1,67 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'Alarm Request' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "type" => "Alarm",
+    "mId" => "E68A0010-C336-41ac-BD58-5C80A72C7092",
+    "cId" => "AB+84001=860SG001",
+    "aCId" => "A0001",
+    "xACId" => "Serious lamp error",
+    "aSp" => "Request"
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'rejects lowercase aSp' do
+    message["aSp"] = 'request'
+    expect( validate(message) ).to be == (
+      [["/aSp", "enum"]]
+    )
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches missing alarm code id' do
+    message.delete 'aCId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["aCId"]}]]
+    )
+  end
+
+  it 'catches bad alarm code id' do
+    message['aCId'] = "001"
+    expect( validate(message) ).to be == (
+      [["/aCId", "pattern"]]
+    )
+  end
+
+  it 'catches wrong alarm code id type' do
+    message['aCId'] = 123
+    expect( validate(message) ).to be == (
+      [["/aCId", "string"]]
+    )
+  end
+
+  it 'catches missing extended alarm code id' do
+    message.delete 'xACId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["xACId"]}]]
+    )
+  end
+
+  it 'catches wrong extended alarm code id type' do
+    message['xACId'] = 123
+    expect( validate(message) ).to be == (
+      [["/xACId", "string"]]
+    )
+  end
+end

--- a/test/schema/alarm_suspend.rb
+++ b/test/schema/alarm_suspend.rb
@@ -1,0 +1,26 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'Alarm Suspend' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "type" => "Alarm",
+    "mId" => "E68A0010-C336-41ac-BD58-5C80A72C7092",
+    "cId" => "AB+84001=860SG001",
+    "aCId" => "A0001",
+    "xACId" => "",
+    "aSp" => "Suspend",
+    "aTs" => "2009-10-01T11:59:31.571Z"
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'rejects lowercase aSp' do
+    message['aSp'] = "suspend"
+    expect( validate(message) ).to be == (
+      [["/aSp", "enum"]]
+    )
+  end
+end

--- a/test/schema/alarm_suspended.rb
+++ b/test/schema/alarm_suspended.rb
@@ -1,0 +1,36 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'Alarm Suspended' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "type" => "Alarm",
+    "mId" => "E68A0010-C336-41ac-BD58-5C80A72C7092",
+    "cId" => "AB+84001=860SG001",
+    "aCId" => "A0001",
+    "xACId" => "",
+    "aSp" => "Suspend",
+    "ack" => "notAcknowledged",
+    "aS" => "Active",
+    "sS" => "Suspended",
+    "aTs" => "2009-10-01T11:59:31.571Z",
+    "cat" => "D",
+    "pri" => "2",
+    "rvs" => [
+      { "n" => "color", "v" => "red" }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'rejects lowercase aS variants' do
+    ["active", "inactive", "InActive"].each do |status|
+      message["aS"] = status
+      expect( validate(message) ).to be == (
+        [["/aS", "enum"]]
+      )
+    end
+  end
+end

--- a/test/schema/command_request.rb
+++ b/test/schema/command_request.rb
@@ -1,0 +1,91 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'CommandRequest' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "CommandRequest",
+    "cId" => "O+14439=481WA001",
+    "arg" => [
+      {
+        "cCI" => "M0001",
+        "n" => "status",
+        "cO" => "setValue",
+        "v" => "YellowFlash"
+      }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches missing arg' do
+    message.delete 'arg'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["arg"]}]]
+    )
+  end
+
+  it 'catches empty arg array' do
+    message["arg"].clear
+    expect( validate(message) ).to be == (
+      [["/arg", "minItems"]]
+    )
+  end
+
+  it 'catches bad arg type' do
+    message["arg"] = {}
+    expect( validate(message) ).to be == (
+      [["/arg", "array"]]
+    )
+  end
+
+  it 'catches missing command code id' do
+    message["arg"].first.delete 'cCI'
+    expect( validate(message) ).to be == (
+      [["/arg/0", "required", {"missing_keys"=>["cCI"]}]]
+    )
+  end
+
+  it 'catches bad command code id' do
+    message["arg"].first['cCI'] = 3
+    expect( validate(message) ).to be == (
+      [["/arg/0/cCI", "string"]]
+    )
+
+    message["arg"].first['cCI'] = '3'
+    expect( validate(message) ).to be == (
+      [["/arg/0/cCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing name' do
+    message["arg"].first.delete 'n'
+    expect( validate(message) ).to be == (
+      [["/arg/0", "required", {"missing_keys"=>["n"]}]]
+    )
+  end
+
+  it 'catches missing command' do
+    message["arg"].first.delete 'cO'
+    expect( validate(message) ).to be == (
+      [["/arg/0", "required", {"missing_keys"=>["cO"]}]]
+    )
+  end
+
+  it 'catches missing value' do
+    message["arg"].first.delete 'v'
+    expect( validate(message) ).to be == (
+      [["/arg/0", "required", {"missing_keys"=>["v"]}]]
+    )
+  end
+end

--- a/test/schema/command_response.rb
+++ b/test/schema/command_response.rb
@@ -1,0 +1,106 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'CommandResponse' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "CommandResponse",
+    "cId" => "O+14439=481WA001",
+    "cTS" => "2015-06-08T08:05:06.584Z",
+    "rvs" => [
+      {
+        "cCI" => "M0001",
+        "n" => "status",
+        "v" => "YellowFlash",
+        "age" => "recent"
+      }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches missing timestamp' do
+    message.delete 'cTS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cTS"]}]]
+    )
+  end
+
+  it 'catches bad timestamp' do
+    message['cTS'] = "yesterday"
+    expect( validate(message) ).to be == (
+      [["/cTS", "pattern"]]
+    )
+  end
+
+  it 'catches missing rvs' do
+    message.delete 'rvs'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["rvs"]}]]
+    )
+  end
+
+  it 'catches bad rvs type' do
+    message["rvs"] = {}
+    expect( validate(message) ).to be == (
+      [["/rvs", "array"]]
+    )
+  end
+
+  it 'catches missing command code id' do
+    message["rvs"].first.delete 'cCI'
+    expect( validate(message) ).to be == (
+      [["/rvs/0", "required", {"missing_keys"=>["cCI"]}]]
+    )
+  end
+
+  it 'catches bad command code id' do
+    message["rvs"].first['cCI'] = 3
+    expect( validate(message) ).to be == (
+      [["/rvs/0/cCI", "string"]]
+    )
+
+    message["rvs"].first['cCI'] = '3'
+    expect( validate(message) ).to be == (
+      [["/rvs/0/cCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing name' do
+    message["rvs"].first.delete 'n'
+    expect( validate(message) ).to be == (
+      [["/rvs/0", "required", {"missing_keys"=>["n"]}]]
+    )
+  end
+
+  it 'catches missing value' do
+    message["rvs"].first.delete 'v'
+    expect( validate(message) ).to be == (
+      [["/rvs/0", "required", {"missing_keys"=>["v"]}]]
+    )
+  end
+
+  it 'catches missing age' do
+    message["rvs"].first.delete 'age'
+    expect( validate(message) ).to be == (
+      [["/rvs/0", "required", {"missing_keys"=>["age"]}]]
+    )
+  end
+
+  it 'catches bad age' do
+    message["rvs"].first['age'] = "bad"
+    expect( validate(message) ).to be == (
+      [["/rvs/0/age", "enum"]]
+    )
+  end
+end

--- a/test/schema/core.rb
+++ b/test/schema/core.rb
@@ -1,0 +1,68 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'Core message fields' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "CommandRequest",
+    "siteId" => [
+      { "sId" => "RN+SI0001" }
+    ],
+    "cId" => "O+14439=481WA001",
+    "arg" => [
+      {
+        "cCI" => "M0001",
+        "n" => "status",
+        "cO" => "setValue",
+        "v" => "YellowFlash"
+      }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing mType' do
+    message.delete 'mType'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["mType"]}]]
+    )
+  end
+
+  it 'catches missing mId' do
+    message.delete 'mId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["mId"]}]]
+    )
+  end
+
+  it 'catches missing type' do
+    message.delete 'type'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["type"]}]]
+    )
+  end
+
+  it 'catches bad mType' do
+    message['mType'] = 'ohno'
+    expect( validate(message) ).to be == (
+      [["/mType", "const"]]
+    )
+  end
+
+  it 'catches bad mId' do
+    message['mId'] = '4173c2c8a93343cb942566d4613731ed'  # missing dashes
+    expect( validate(message) ).to be == (
+      [["/mId", "pattern"]]
+    )
+  end
+
+  it 'catches bad type' do
+    message['type'] = 'MyMessage'
+    expect( validate(message) ).to be == (
+      [["/type", "enum"]]
+    )
+  end
+end

--- a/test/schema/message_ack.rb
+++ b/test/schema/message_ack.rb
@@ -1,0 +1,29 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'MessageAck' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "MessageAck",
+    "oMId" => "49c6c824-a933-47e3-b9ff-15aa8b5bbeef"
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing oMId' do
+    message.delete 'oMId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["oMId"]}]]
+    )
+  end
+
+  it 'catches bad oMId' do
+    message['oMId'] = '4173c2c8a93343cb942566d4613731ed'  # missing dashes
+    expect( validate(message) ).to be == (
+      [["/oMId", "pattern"]]
+    )
+  end
+end

--- a/test/schema/message_not_ack.rb
+++ b/test/schema/message_not_ack.rb
@@ -1,0 +1,52 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'MessageNotAck' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "siteId" => [
+      { "sId" => "RN+SI0001" }
+    ],
+    "type" => "MessageNotAck",
+    "oMId" => "92b9706d-0466-4518-8663-00b9690e9c41",
+    "rea" => "Unknown json type: Watchdog"
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing oMId' do
+    message.delete 'oMId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["oMId"]}]]
+    )
+  end
+
+  it 'catches bad oMId format' do
+    message['oMId'] = '4173c2c8-a933-ouch-9425-66d4613731ed'
+    expect( validate(message) ).to be == (
+      [["/oMId", "pattern"]]
+    )
+  end
+
+  it 'catches wrong oMId type' do
+    message['oMId'] = 1234
+    expect( validate(message) ).to be == (
+      [["/oMId", "string"]]
+    )
+  end
+
+  it 'allows reason to be omitted' do
+    message.delete 'rea'
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches bad reason, must be string' do
+    message['rea'] = 123
+    expect( validate(message) ).to be == (
+      [["/rea", "string"]]
+    )
+  end
+end

--- a/test/schema/status_request.rb
+++ b/test/schema/status_request.rb
@@ -1,0 +1,79 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'StatusRequest' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "StatusRequest",
+    "cId" => "O+14439=481WA001",
+    "sS" => [
+      { "sCI" => "S0003", "n" => "inputstatus" }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches missing sS' do
+    message.delete 'sS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["sS"]}]]
+    )
+  end
+
+  it 'catches empty sS array' do
+    message['sS'].clear
+    expect( validate(message) ).to be == (
+      [["/sS", "minItems"]]
+    )
+  end
+
+  it 'catches bad sS type' do
+    message['sS'] = {}
+    expect( validate(message) ).to be == (
+      [["/sS", "array"]]
+    )
+  end
+
+  it 'catches missing status code id' do
+    message['sS'].first.delete 'sCI'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["sCI"]}]]
+    )
+  end
+
+  it 'catches bad status code id' do
+    message['sS'].first['sCI'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "string"]]
+    )
+
+    message['sS'].first['sCI'] = '3'
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing name' do
+    message['sS'].first.delete 'n'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["n"]}]]
+    )
+  end
+
+  it 'catches bad name type' do
+    message['sS'].first['n'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/n", "string"]]
+    )
+  end
+end

--- a/test/schema/status_response.rb
+++ b/test/schema/status_response.rb
@@ -1,0 +1,138 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'StatusResponse' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "StatusResponse",
+    "cId" => "O+14439=481WA001",
+    "sTs" => "2015-06-08T09:15:18.266Z",
+    "sS" => [
+      { "sCI" => "S0003", "n" => "inputstatus", "s" => "100101", "q" => "recent" }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'accepts q=undefined, s=null' do
+    message["sS"].first["q"] = "undefined"
+    message["sS"].first["s"] = nil
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'rejects q=recent, s=null' do
+    message["sS"].first["q"] = "recent"
+    message["sS"].first["s"] = nil
+    expect( validate(message) ).to be == (
+      [["/sS/0/s", "type"]]
+    )
+  end
+
+  it 'rejects q=undefined, s=string' do
+    message["sS"].first["q"] = "undefined"
+    message["sS"].first["s"] = "something"
+    expect( validate(message) ).to be == (
+      [["/sS/0/s", "null"]]
+    )
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches bad status code' do
+    message['sS'].first['sCI'] = '99'
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing sS' do
+    message.delete 'sS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["sS"]}]]
+    )
+  end
+
+  it 'catches empty sS array' do
+    message['sS'].clear
+    expect( validate(message) ).to be == (
+      [["/sS", "minItems"]]
+    )
+  end
+
+  it 'catches bad sS type' do
+    message['sS'] = {}
+    expect( validate(message) ).to be == (
+      [["/sS", "array"]]
+    )
+  end
+
+  it 'catches missing status code id' do
+    message['sS'].first.delete 'sCI'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["sCI"]}]]
+    )
+  end
+
+  it 'catches bad status code id' do
+    message['sS'].first['sCI'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "string"]]
+    )
+
+    message['sS'].first['sCI'] = '3'
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing name' do
+    message['sS'].first.delete 'n'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["n"]}]]
+    )
+  end
+
+  it 'catches bad name type' do
+    message['sS'].first['n'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/n", "string"]]
+    )
+  end
+
+  it 'catches n set to null' do
+    message['sS'].first['n'] = nil
+    expect( validate(message) ).to be == (
+      [["/sS/0/n", "string"]]
+    )
+  end
+
+  it 'catches missing value' do
+    message['sS'].first.delete 's'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["s"]}]]
+    )
+  end
+
+  it 'catches missing quality' do
+    message['sS'].first.delete 'q'
+    expect( validate(message) ).to be == (
+      [["/sS/0/s", "null"],
+       ["/sS/0", "required", {"missing_keys"=>["q"]}]]
+    )
+  end
+
+  it 'catches bad quality' do
+    message['sS'].first['q'] = 'great'
+    expect( validate(message) ).to be == (
+      [["/sS/0/q", "enum"]]
+    )
+  end
+end

--- a/test/schema/status_subscribe.rb
+++ b/test/schema/status_subscribe.rb
@@ -1,0 +1,119 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'StatusSubscribe' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "StatusSubscribe",
+    "cId" => "O+14439=481WA001",
+    "sS" => [
+      { "sCI" => "S0003", "n" => "inputstatus", "uRt" => "0", "sOc" => true }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches missing sS' do
+    message.delete 'sS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["sS"]}]]
+    )
+  end
+
+  it 'catches empty sS array' do
+    message['sS'].clear
+    expect( validate(message) ).to be == (
+      [["/sS", "minItems"]]
+    )
+  end
+
+  it 'catches bad sS type' do
+    message['sS'] = {}
+    expect( validate(message) ).to be == (
+      [["/sS", "array"]]
+    )
+  end
+
+  it 'catches missing status code id' do
+    message['sS'].first.delete 'sCI'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["sCI"]}]]
+    )
+  end
+
+  it 'catches bad status code id' do
+    message['sS'].first['sCI'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "string"]]
+    )
+
+    message['sS'].first['sCI'] = '3'
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing name' do
+    message['sS'].first.delete 'n'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["n"]}]]
+    )
+  end
+
+  it 'catches bad name type' do
+    message['sS'].first['n'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/n", "string"]]
+    )
+  end
+
+  it 'catches missing uRt' do
+    message['sS'].first.delete 'uRt'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["uRt"]}]]
+    )
+  end
+
+  it 'catches bad uRt type' do
+    message['sS'].first['uRt'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/uRt", "string"]]
+    )
+
+    message['sS'].first['uRt'] = "fast"
+    expect( validate(message) ).to be == (
+      [["/sS/0/uRt", "pattern"]]
+    )
+  end
+
+  it 'catches sOc wrongly typed as string' do
+    message['sS'].first['sOc'] = "True"
+    expect( validate(message) ).to be == (
+      [["/sS/0/sOc", "boolean"]]
+    )
+  end
+
+  it 'catches missing sOc' do
+    message['sS'].first.delete 'sOc'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["sOc"]}]]
+    )
+  end
+
+  it 'catches extra attributes' do
+    message['sS'].first['bad'] = "Foo"
+    expect( validate(message) ).to be == (
+      [["/sS/0/bad", "schema"]]
+    )
+  end
+end

--- a/test/schema/status_unsubscribe.rb
+++ b/test/schema/status_unsubscribe.rb
@@ -1,0 +1,93 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'StatusUnsubscribe' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "StatusUnsubscribe",
+    "cId" => "O+14439=481WA001",
+    "sS" => [
+      { "sCI" => "S0003", "n" => "inputstatus" }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches bad status code' do
+    message['sS'].first['sCI'] = '99'
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing sS' do
+    message.delete 'sS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["sS"]}]]
+    )
+  end
+
+  it 'catches empty sS array' do
+    message['sS'].clear
+    expect( validate(message) ).to be == (
+      [["/sS", "minItems"]]
+    )
+  end
+
+  it 'catches bad sS type' do
+    message['sS'] = {}
+    expect( validate(message) ).to be == (
+      [["/sS", "array"]]
+    )
+  end
+
+  it 'catches missing status code id' do
+    message['sS'].first.delete 'sCI'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["sCI"]}]]
+    )
+  end
+
+  it 'catches bad status code id' do
+    message['sS'].first['sCI'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "string"]]
+    )
+
+    message['sS'].first['sCI'] = '3'
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing name' do
+    message['sS'].first.delete 'n'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["n"]}]]
+    )
+  end
+
+  it 'catches bad name type' do
+    message['sS'].first['n'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/n", "string"]]
+    )
+  end
+
+  it 'catches extra attributes' do
+    message['sS'].first['bad'] = "Foo"
+    expect( validate(message) ).to be == (
+      [["/sS/0/bad", "schema"]]
+    )
+  end
+end

--- a/test/schema/status_update.rb
+++ b/test/schema/status_update.rb
@@ -1,0 +1,108 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'StatusUpdate' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "StatusUpdate",
+    "cId" => "O+14439=481WA001",
+    "sTs" => "2015-06-08T09:15:18.266Z",
+    "sS" => [
+      { "sCI" => "S0003", "n" => "inputstatus", "s" => "100101", "q" => "recent" }
+    ]
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing component id' do
+    message.delete 'cId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["cId"]}]]
+    )
+  end
+
+  it 'catches bad status code' do
+    message['sS'].first['sCI'] = '99'
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing sS' do
+    message.delete 'sS'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["sS"]}]]
+    )
+  end
+
+  it 'catches empty sS array' do
+    message['sS'].clear
+    expect( validate(message) ).to be == (
+      [["/sS", "minItems"]]
+    )
+  end
+
+  it 'catches bad sS type' do
+    message['sS'] = {}
+    expect( validate(message) ).to be == (
+      [["/sS", "array"]]
+    )
+  end
+
+  it 'catches missing status code id' do
+    message['sS'].first.delete 'sCI'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["sCI"]}]]
+    )
+  end
+
+  it 'catches bad status code id' do
+    message['sS'].first['sCI'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "string"]]
+    )
+
+    message['sS'].first['sCI'] = '3'
+    expect( validate(message) ).to be == (
+      [["/sS/0/sCI", "pattern"]]
+    )
+  end
+
+  it 'catches missing name' do
+    message['sS'].first.delete 'n'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["n"]}]]
+    )
+  end
+
+  it 'catches bad name type' do
+    message['sS'].first['n'] = 3
+    expect( validate(message) ).to be == (
+      [["/sS/0/n", "string"]]
+    )
+  end
+
+  it 'catches n set to null' do
+    message['sS'].first['n'] = nil
+    expect( validate(message) ).to be == (
+      [["/sS/0/n", "string"]]
+    )
+  end
+
+  it 'catches missing value' do
+    message['sS'].first.delete 's'
+    expect( validate(message) ).to be == (
+      [["/sS/0", "required", {"missing_keys"=>["s"]}]]
+    )
+  end
+
+  it 'catches bad quality' do
+    message['sS'].first['q'] = 'great'
+    expect( validate(message) ).to be == (
+      [["/sS/0/q", "enum"]]
+    )
+  end
+end

--- a/test/schema/version.rb
+++ b/test/schema/version.rb
@@ -1,0 +1,135 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'Version' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "a28e94b9-05c7-41bb-8f8b-54693adc9698",
+    "siteId" => [
+      { "sId" => "RN+SI0001" }
+    ],
+    "type" => "Version",
+    "RSMP" => [
+      { "vers" => "3.2.0" },
+      { "vers" => "3.2.1" },
+      { "vers" => "3.2.2" }
+    ],
+    "SXL" => "1.2.1"
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing mId' do
+    message.delete 'mId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["mId"]}]]
+    )
+  end
+
+  it 'catches missing siteId' do
+    message.delete 'siteId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["siteId"]}]]
+    )
+  end
+
+  it 'catches bad siteId format, must be array' do
+    message['siteId'] = '1.0'
+    expect( validate(message) ).to be == (
+      [["/siteId", "array"]]
+    )
+  end
+
+  it 'catches bad siteId format, array cannot be empty' do
+    message['siteId'] = []
+    expect( validate(message) ).to be == (
+      [["/siteId", "minItems"]]
+    )
+  end
+
+  it 'catches bad siteId format, item must be hash' do
+    message['siteId'] = ['1.0']
+    expect( validate(message) ).to be == (
+      [["/siteId/0", "object"]]
+    )
+  end
+
+  it 'catches bad siteId format, item must have version' do
+    message['siteId'] = [{}]
+    expect( validate(message) ).to be == (
+      [["/siteId/0", "required", {"missing_keys"=>["sId"]}]]
+    )
+  end
+
+  it 'catches bad siteId format, item cannot have extra attributes' do
+    message['siteId'] = [{'sId'=>'RN+SI0001','extra'=>'123'}]
+    expect( validate(message) ).to be == (
+      [["/siteId/0/extra", "schema"]]
+    )
+  end
+
+  it 'catches missing RSMP version' do
+    message.delete 'RSMP'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["RSMP"]}]]
+    )
+  end
+
+  it 'catches bad RSMP format, must be array' do
+    message['RSMP'] = '1.0'
+    expect( validate(message) ).to be == (
+      [["/RSMP", "array"]]
+    )
+  end
+
+  it 'catches bad RSMP format, array cannot be empty' do
+    message['RSMP'] = []
+    expect( validate(message) ).to be == (
+      [["/RSMP", "minItems"]]
+    )
+  end
+
+  it 'catches bad RSMP format, item must be hash' do
+    message['RSMP'] = ['1.0']
+    expect( validate(message) ).to be == (
+      [["/RSMP/0", "object"]]
+    )
+  end
+
+  it 'catches bad RSMP format, item must have version' do
+    message['RSMP'] = [{}]
+    expect( validate(message) ).to be == (
+      [["/RSMP/0", "required", {"missing_keys"=>["vers"]}]]
+    )
+  end
+
+  it 'catches bad RSMP format, item cannot have extra attributes' do
+    message['RSMP'] = [{'vers'=>'1.0.0','extra'=>'123'}]
+    expect( validate(message) ).to be == (
+      [["/RSMP/0/extra", "schema"]]
+    )
+  end
+
+  it 'catches bad RSMP format, version must be 1.0.0 format' do
+    message['RSMP'].first['vers'] = 'latest'
+    expect( validate(message) ).to be == (
+      [["/RSMP/0/vers", "pattern"]]
+    )
+  end
+
+  it 'catches missing SXL version' do
+    message.delete 'SXL'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["SXL"]}]]
+    )
+  end
+
+  it 'catches bad SXL version' do
+    message['SXL'] = 'Release 1.0.1'
+    expect( validate(message) ).to be == (
+      [["/SXL", "pattern"]]
+    )
+  end
+end

--- a/test/schema/watchdog.rb
+++ b/test/schema/watchdog.rb
@@ -1,0 +1,36 @@
+require 'sus'
+require_relative '../support/validate'
+
+describe 'Watchdog' do
+  let(:message) {{
+    "mType" => "rSMsg",
+    "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
+    "type" => "Watchdog",
+    "wTs" => "2015-06-08T12:01:39.654Z"
+  }}
+
+  it 'accepts valid message' do
+    expect( validate(message) ).to be_nil
+  end
+
+  it 'catches missing mId' do
+    message.delete 'mId'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["mId"]}]]
+    )
+  end
+
+  it 'catches missing timestamp' do
+    message.delete 'wTs'
+    expect( validate(message) ).to be == (
+      [["", "required", {"missing_keys"=>["wTs"]}]]
+    )
+  end
+
+  it 'catches bad timestamp format' do
+    message['wTs'] = '2015-06-08T12:01:39.654'  # missing Z at end
+    expect( validate(message) ).to be == (
+      [["/wTs", "pattern"]]
+    )
+  end
+end

--- a/test/support/validate.rb
+++ b/test/support/validate.rb
@@ -1,0 +1,13 @@
+# Helper for validating schema files
+
+require 'json_schemer'
+require 'pathname'
+
+SCHEMA = JSONSchemer.schema(
+  Pathname.new(File.expand_path('../../schema/rsmp.json', __dir__))
+)
+
+def validate(message)
+  errors = SCHEMA.validate(message).map { |e| [e['data_pointer'], e['type'], e['details']].compact }
+  errors.empty? ? nil : errors
+end


### PR DESCRIPTION
As part of repo reorganization, we're folding rsmp_schema into the rsmp gem, and moving the schema files to the the core/sxl repos.

rsmp_schema had tests validating the schemas, but for all versions. This PR moves relevant tests here to the core repo, so we can validate schema where they are maintained. Test use Ruby and the sus test framework:

% bundle install
% bundle exec sus
194 passed out of 194 total (206 assertions)
🏁 Finished in 151.2ms; 1362.605 assertions per second.
🤩 Your test suite is amazing!
🎉 Great job! Your test suite has excellent performance (1362.6 < 10000)!
🐇 No slow tests found! Well done!

There's a Gemfile, but that's minimal and you don't need to install Ruby/gems unles you want to run the schema test.

I'm also moving core schema tests to this repo for all other older versions. For those I plan t just push to the relevant branches without PRs, but will while until this PR  has been merged, in case there are comments on the approach in general.
