### PR TITLE
Remove Excel as a way to define SXLs

### DIFF
--- a/source/applicability/site_configuration.rst
+++ b/source/applicability/site_configuration.rst
@@ -5,52 +5,13 @@ Site configuration
 A site configuration defines the individual components that exists
 in a specific site. It also defines the relationship between those components.
 
-The site configuration can either be defined as a separate YAML file or be
-combined with the YAML file of the SXL when needed. The Excel file always
-combines the SXL and the site configuration.
-
-Meta data
----------
-In order to uniquely identify an SXL and site configuration for a
-supervision system the site id and the version needs to be known.
-See :ref:`rsmpsxl-version`. The SXL defines the site id, but meta data is
-needed to provide the SXL version.
-
-The site configuration may define a set of meta data of a specific site.
-It is defined in the first sheet named "Version" in in the Excel version and at
-the very top of the YAML version.
-
-In each SXL it must defined which version of RSMP it conforms to.
-
-It contains:
-
-.. table:: meta data
-
-   ================= ================
-   Excel             YAML
-   ================= ================
-   Plant id          ``id``
-   Plant name        ``description``
-   Constructor       ``constructor``
-   Reviewed          *(not used)*
-   Approved          *(not used)*
-   Created date      ``created-date``
-   SXL revision [#]_ ``version``
-   RSMP version      ``rsmp-version``
-   ================= ================
-
-.. rubric:: Footnotes
-
-.. [#] Revision number and Revision date
-
+The site configuration is defined using YAML format.
 
 Components
 ----------
 A site consists of components, identified by unique component ids (``cId``).
 
-Using the Excel format; components are defined in it's own sheet - one for each
-site.
-Using the YAML format, each component is defined like this:
+Each component is defined like this:
 
 .. code-block:: yaml
 

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -6,6 +6,8 @@ A signal exchange list (:term:`SXL`) specifies the interface for a type of equip
 
 An SXL is identified by its name, and is published with a version following Semantic Versioning (SemVer) rules.
 
+An SXL is defined using YAML format.
+
 An SXL defines component types, and the alarm, command, and status messages used to interact with these component types.
 It also details the meaning of aggregated status bits, functional positions and functional states.
 
@@ -168,10 +170,7 @@ Messages
 The message types **Alarm**, **Aggregated status**, **Status** and **Commands**
 are defined in the SXL.
 
-Using the Excel format; alarms, aggregated status, status and commands are
-defined in their own sheet.
-
-Using the YAML format; each message type is defined like this:
+Each message type is defined like this:
 
 .. code-block:: yaml
 
@@ -267,14 +266,6 @@ An argument contains the fields:
 At least one argument is required for commands and statuses, but they are
 optional in alarms.
 
-
-.. note::
-
-    In the Excel version of the SXL, there is no separate min and max columns.
-    Instead, allowed values can be defined using the Value column according
-    to the following example: [0-100], where 0 is the minimum value and 100 is
-    the maximum value.
-
 The aggregated status contains the fields:
 
 - ``functional_position`` is the :term:`Functional position`
@@ -356,12 +347,6 @@ The following table defines the functional differences between message types.
    Status             On request *or* according to subscription  No
    Command            On request                                 Yes, partly (functional status)
    =================  =========================================  ================================
-
-.. note::
-   In addition to :term:`functional position`, the Excel version of the SXL
-   can also differentiate between different kinds of command messages using
-   :term:`maneuver` and :term:`parameter` sections. However, their use has no
-   functional significance from a protocol point of view.
 
 Arguments and return values
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Excel has lagged behind in support for the newer features of RSMP. It's time to discontinue support for Excel and focus on YAML.