### PR TITLE
Deprecate external NTS alarm code id (xNACId)

### DIFF
--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -28,7 +28,7 @@ In the following example the message type is an alarm message.
        "cId": "AB+84001=860SG001",
        "aCId": "A0001",
        "xACId": "Serious lamp error",
-       "xNACId": "3143",
+       "xNACId": "",
        "aSp": "Issue",
        "ack": "notAcknowledged",
        "aS": "Active",
@@ -178,7 +178,7 @@ An alarm message has the structure according to the example below.
        "cId": "AB+84001=860SG001",
        "aCId": "A0001",
        "xACId": "Serious lamp error",
-       "xNACId": "3143",
+       "xNACId": "",
        "aSp": "Issue",
        "ack": "notAcknowledged",
        "aS": "Active",
@@ -209,7 +209,7 @@ defined by the SXL.
    ============ ==================================
    aCId         :term:`Alarm code id`
    xACId        :term:`External alarm code id`
-   xNACId       :term:`External NTS alarm code id`
+   xNACId       *deprecated (empty string)*
    ============ ==================================
 
 The following table describes additional variable content of the message.

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -205,7 +205,6 @@ Each message type is defined like this:
           priority: 1
           category: D
           externalAlarmCodeId: manufacturer specific alarm text
-          externalNtsAlarmCodeId: 0000
           arguments:
             <argument-1>:
               type: integer
@@ -245,7 +244,6 @@ The alarm contains the fields:
 - ``category`` is the alarm category
 - ``priority`` is the alarm priority
 - ``externalAlarmCodeId`` is the :term:`External alarm code id`
-- ``externalNtsAlarmCodeId`` is the :term:`External NTS alarm code id`
 
 The status contains the fields:
 

--- a/source/definitions.rst
+++ b/source/definitions.rst
@@ -26,9 +26,6 @@ Definitions
        Includes manufacturer, model, internal alarm code och additional
        alarm description.
 
-   External NTS alarm code id
-       Alarm code in order to identify alarm type during communication with NTS
-
    Functional position
        Provides command options for a site. For instance, "start" or "stop"
        It is meant to be used for the entire site and not for an individual


### PR DESCRIPTION
Original issue: https://github.com/rsmp-nordic/rsmp_core/issues/89