### PR TITLE
add security considerings, remove TLS version requirements

### DIFF
--- a/source/applicability.rst
+++ b/source/applicability.rst
@@ -7,6 +7,7 @@ Applicability
    :maxdepth: 2
     
    applicability/scope
+   applicability/security_considerations
    applicability/object_model
    applicability/transport_of_data
    applicability/basic_structure
@@ -17,4 +18,3 @@ Applicability
    applicability/sxl_processing
    applicability/site_configuration
    applicability/persistence
-

--- a/source/applicability/scope.rst
+++ b/source/applicability/scope.rst
@@ -16,3 +16,7 @@ Responsibility
 information only. RSMP Nordic is not responsible for any consequences
 that implementation of the specification can lead to for the supplier
 or any third party.
+
+RSMP Nordic's responsibilities for maintaining the specification, and the
+responsibilities of system owners and suppliers when deploying RSMP, are
+described on the `RSMP Nordic website <https://rsmp-nordic.org/>`_.

--- a/source/applicability/security_considerations.rst
+++ b/source/applicability/security_considerations.rst
@@ -1,0 +1,67 @@
+.. _security-considerations:
+
+Security considerations
+-----------------------
+
+Security scope
+^^^^^^^^^^^^^^
+
+RSMP Core defines an application protocol for exchanging messages between
+sites and supervision systems. RSMP Core does not require protected
+communication and does not add cryptographic protection to RSMP messages.
+
+When RSMP is used over an unprotected TCP connection, an attacker with access
+to the network can read RSMP data and can attempt to modify, inject, or replay
+messages. Message acknowledgements and message identifiers are protocol
+features, not cryptographic protection. They do not provide
+confidentiality, peer authentication, or protection against a network attacker.
+
+External communication protection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As described in :ref:`transport-security`, a deployment can use TLS, a VPN, or
+another external mechanism to protect the communication carrying RSMP. These
+mechanisms do not change RSMP messages or protocol behaviour and are not part
+of RSMP Core conformance.
+
+TLS can protect the TCP connection between the endpoints that terminate TLS. A
+VPN can protect network traffic between the endpoints of the VPN tunnel. Both
+can provide confidentiality, integrity, and peer authentication within their
+respective trust boundaries when configured and validated correctly.
+
+Selection of a protection mechanism and its versions, identities, trust
+configuration, credentials, and operation are deployment responsibilities.
+RSMP Core does not define a TLS or VPN security profile.
+
+Trust boundary and intermediaries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Communication protection applies only between the endpoints that terminate
+it. TLS endpoints are commonly application processes or devices. VPN endpoints
+may instead be hosts or network gateways. Traffic outside those endpoints is
+not protected by that mechanism.
+
+An intermediary that terminates protection may be able to read or modify RSMP
+messages unless additional end-to-end protection is used. Separate protected
+connections are needed on both sides of such an intermediary when protection
+is required across the complete path.
+
+Limitations
+^^^^^^^^^^^
+
+External communication protection does not protect against:
+
+* compromise of a site, supervision system, or trusted intermediary
+* disclosure or unauthorized use of endpoint credentials or private keys
+* denial of service or traffic analysis
+* insecure device firmware, operating systems, administrative interfaces, or
+  software updates
+* disclosure of RSMP data in application logs, databases, backups, or other
+  storage outside the protected connection
+* unsafe application behaviour or incorrect authorization of commands
+
+The system owner and suppliers are responsible for the security and safety of
+the complete deployment, including devices, networks, credentials, operations,
+monitoring, incident response, and compliance. The division of responsibilities
+between RSMP Nordic and deployers is described on the
+`RSMP Nordic website <https://rsmp-nordic.org/>`_.

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -101,30 +101,18 @@ Alarms:
   this affects all supervisors.
 
 
+.. _transport-security:
+
 Security
 ^^^^^^^^
 
-.. note::
-   Implementing support for encryption is not required unless otherwise stated.
+RSMP Core does not provide communication security. A deployment can protect
+the TCP connection carrying RSMP by using an external mechanism such as TLS or
+a VPN. This protection does not change RSMP messages or protocol behaviour.
 
-If encryption is used then the following applies:
-
-* Encryption settings needs to be configurable in both the supervision system as
-  well as the site.
-
-* For the encrypted communication, TLS 1.3 or later is used.
-
-* Encrypted communication should use a separate port number.
-  By default this should be port 12112.
-
-* If both the supervision system and site are configured to use encryption,
-  certificates should be used to verify the identities of each other.
-
-* Equipment which uses RSMP should contain a user interface for easy management
-  of certificates.
-
-* The issuing and renewal of certificates should should be made in cooperation
-  with the purchaser unless other arrangement is agreed upon.
+RSMP Core does not define requirements for selecting, configuring, or
+operating TLS, a VPN, or another external protection mechanism. See
+:ref:`security-considerations`.
 
 .. _communication-establishment-between-sites-and-supervision-system:
 

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -26,6 +26,8 @@ The full list of changes between version 3.3.0 and 3.2.2 can be viewed on github
 
 - Remove reference to Datex II. :issue:`185`
 - Clarify aggregated status. :issue:`200`
+- Add security considerations, clarify that communication protection is
+  external to RSMP Core, and remove operational TLS recommendations.
 
 Version 3.2.2
 -------------


### PR DESCRIPTION
This PR updates descriptions of security. It's part of an effort to streamline how to describe and work with security.

The current wording could implied that core defines an RSMP-specific TLS integration. But core just mentions that you can run with TLS and in that case requires a mininum version of TLS.

But I think TLS recommendations like minimum TLS versions is an operational choice. We suggest we instead maintained recommendation on the rsmp website and updated without revising the versioned core spec. See this PR:
https://github.com/rsmp-nordic/rsmp_website/pull/109

VPN is another way to protect the communication channel has is mention alongside TLS.

- add a Security considerations section
- describe the risks of running RSMP over unprotected TCP
- explain TLS and VPN trust boundaries
- document limitations of external communication protection
- clarify the responsibilities of system owners and suppliers
- remove operational TLS requirements from Core, including the TLS version,
  dedicated port, and certificate-management recommendations
- link to the RSMP Nordic website for current deployment and responsibility
  guidance
- update the changelog
