### PR TITLE
support sxl minor and patch compatibility

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -39,6 +39,13 @@
       { "pattern" : "^[0-9]{1,2}\\.[0-9]{1,2}(\\.[0-9]{1,2})?" }
     ]
   },
+  "sxl_version": {
+    "description" : "SXL version in MAJOR.MINOR.PATCH format",
+    "allOf" : [
+      { "$ref" : "#/rsmp_string" },
+      { "pattern" : "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$" }
+    ]
+  },
   "command_code": {
     "description" : "Command code id",
     "allOf" : [
@@ -129,5 +136,4 @@
     ]
   }
 }
-
 

--- a/schema/version.json
+++ b/schema/version.json
@@ -15,11 +15,11 @@
           "description" : "Supported RSMP versions"
         },
         "SXL" : {
-          "$ref": "definitions.json#/version",
+          "$ref": "definitions.json#/sxl_version",
           "description" : "Primary SXL version, for backward compatibility"
         },
         "SXLS" : {
-          "description" : "Supported SXLs",
+          "description" : "Latest SXL version supported by the site in each compatibility series",
           "type" : "array",
           "items" : { "$ref" : "#/$defs/sxl_request" },
           "minItems" : 0,
@@ -60,7 +60,7 @@
           "minLength" : 1
         },
         "SXLS" : {
-          "description" : "SXLs to use, or not use",
+          "description" : "One accepted or rejected result for each SXL name requested by the site",
           "type" : "array",
           "items" : { "$ref" : "#/$defs/sxl_response" },
           "minItems" : 0,
@@ -106,7 +106,7 @@
       "type" : "object",
       "properties" : {
         "name" : { "$ref" : "definitions.json#/sxl_name" },
-        "version" : { "$ref" : "definitions.json#/version" },
+        "version" : { "$ref" : "definitions.json#/sxl_version" },
         "prefix" : { "$ref" : "definitions.json#/sxl_prefix" }
       },
       "required" : [ "name", "version" ],
@@ -118,7 +118,10 @@
         {
           "properties" : {
             "name" : { "$ref" : "definitions.json#/sxl_name" },
-            "version" : { "$ref" : "definitions.json#/version" }
+            "version" : {
+              "$ref" : "definitions.json#/sxl_version",
+              "description" : "SXL version supported by the supervisor"
+            }
           },
           "required" : [ "name", "version" ],
           "additionalProperties" : false
@@ -126,7 +129,7 @@
         {
           "properties" : {
             "name" : { "$ref" : "definitions.json#/sxl_name" },
-            "version" : { "$ref" : "definitions.json#/version" },
+            "version" : { "$ref" : "definitions.json#/sxl_version" },
             "rejected" : {
               "type" : "integer",
               "enum" : [ 1, 2, 3 ]

--- a/source/applicability.rst
+++ b/source/applicability.rst
@@ -15,6 +15,7 @@ Applicability
    applicability/data_types
    applicability/components
    applicability/sxl
+   applicability/sxl_version_compatibility
    applicability/sxl_processing
    applicability/site_configuration
    applicability/persistence

--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -591,9 +591,10 @@ Aggregated status message
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This type of message is sent to the supervision system to inform about the
-status of the site. The aggregated status applies to the component which is
-defined by **ComponentType** in the signal exchange list. If no component is defined
-then no aggregated status message is sent.
+overall status of the site. A single aggregated status represents the entire
+site; it is not maintained or sent separately for each component in the
+ComponentList. Its SXL-defined content applies to the site as a whole. If the
+SXL does not define aggregated status, no aggregated status message is sent.
 
 Aggregated status messages are interaction driven and are sent if state,
 functional position or functional status are changed at the site.
@@ -1250,8 +1251,9 @@ If all required arguments are present and valid, the site immediately sends a Me
 and starts executing the command. Once the execution completes, fails or times
 out the site sends a CommandResponse.
 
-If a required argument is missing or any argument is invalid the site responds with a
-MessageNotAck and does not send a CommandResponse.
+If a required argument is missing or a known argument is invalid, the site responds with a
+MessageNotAck and does not send a CommandResponse. Unknown arguments are handled according
+to :ref:`sxl-version-error-handling`.
 
 All arguments in a CommandRequest are required unless specifically marked as optional
 in the SXL.
@@ -1580,8 +1582,9 @@ The supervisor responds with a Version response message.
 Version messages are used to exchange information about supported versions of RSMP and SXL,
 to ensure that the communicating parties are compatible.
 
-If there is a mismatch or if there are no RSMP versions that both
-communicating parties support, see :ref:`communication-rejection`.
+If there are no RSMP versions that both communicating parties support, see
+:ref:`communication-rejection`. An incompatible SXL does not prevent the
+connection from being established, but cannot be used on the connection.
 
 Unknown fields in Version messages must be ignored and not cause a MessageNotAck.
 This allows for backward compatibility when new fields are added in later versions of RSMP or SXL.
@@ -1597,7 +1600,7 @@ The initial Version request sent by the site contains:
 
 * Site Id.
 * Supported RSMP core versions
-* Supported SXLs and their versions
+* Supported SXLs and their version candidates
 
 .. code-block:: json
    :name: json-version-request
@@ -1638,14 +1641,17 @@ The following table describes variable content of the message:
    siteId        array    Array of site ids. Must contain exactly one object with ``sId`` set to the site id string.
    RSMP          array    Array of supported core versions. 
    SXL           string   Optional. Version of the primary SXL, for backward compatibility.
-   SXLS          array    Array of supported SXLs.
+   SXLS          array    Array of supported SXL version candidates.
    ============= ======== ===============
 
 Only one site can use the same connection. The ``sId`` array must therefore contain
 exactly one element.
 
-The ``SXL`` field is included when a primary SXL exists, for backward compatibility with supervisors that only
-support older core versions and ignore the newer ``SXLS`` array.
+The ``SXL`` field is included when a primary SXL exists, for backward
+compatibility with supervisors that only support older core versions and
+ignore the newer ``SXLS`` array. If the site supports the primary SXL in more
+than one compatibility series, ``SXL`` contains the supported version with the
+highest Semantic Versioning precedence.
 
 The ``SXLS`` array may be empty if the site does not support any SXLs.
 Each item in the ``SXLS`` array must be an object with the following content:
@@ -1658,21 +1664,25 @@ Each item in the ``SXLS`` array must be an object with the following content:
    Element Type     Description  
    ======= ======== ==================== 
    name    string   SXL name, e.g. ``traffic_light_controller``          
-   version string   Version of the SXL, e.g. "1.3.0".
+   version string   Version of the SXL supported by the site, e.g. "1.3.0".
    prefix  string   (Optional) Prefix defined in the SXL. Omitted if the SXL does not define a prefix.
    ======= ======== ====================
 
-If the site supports multiple versions of an SXL the latest must be specified.
+For each SXL, the site must list the latest version it supports in every
+supported non-zero major version. The same SXL name can therefore occur more
+than once, but at most once for each non-zero major version. Because
+major-version-zero versions require an exact match, each supported ``0.y.z``
+version can be listed separately.
 
 
 Version Response
 """""""""""""""""
 Communication can only be established if the supervisor supports one of the core
-versions listed in the version request sent by the site. It must be an exact match of both
-major, minor and patch version.
+versions listed in the version request sent by the site. It must be an exact match of the
+major, minor and patch versions.
 
-An SXL listed by the site can only be used if the supervisor supports the exact same version,
-with an exact match of both major, minor and patch version.
+An SXL listed by the site can be used if the supervisor supports a compatible version,
+as defined in :ref:`sxl-version-compatibility`.
 
 Communication can be established even if the supervisor supports none of the SXLs. In this case, no
 commands, statuses or alarms can be exchanged, only aggregated status.
@@ -1680,12 +1690,15 @@ commands, statuses or alarms can be exchanged, only aggregated status.
 If the supervisor determines that the core version cannot be matched,
 it must send a MessageNotAck and close the connection, see :ref:`communication-rejection`.
 
-If the core version can be matched, the supervisor returns a Version response containing:
+If the core version can be matched, the supervisor returns a Version response
+containing:
 
 * Supervisor ID.
 * RSMP core version to use.
-* SXLs to use.
-* SXLs not to use and why.
+* Exactly one accepted or rejected result for each distinct SXL name in the
+  Version request.
+* The supervisor's version for each accepted SXL.
+* The reason for each rejected SXL.
 * receiveAlarms flag, indicating whether the supervisor wants to receive alarms.
 
 .. code-block:: json
@@ -1697,26 +1710,28 @@ If the core version can be matched, the supervisor returns a Version response co
          "step": "Response",
          "mId": "6f968141-4de5-42ff-8032-45f8093762c5",
          "RSMP": [
-            { "vers": "3.1.1" }
+            { "vers": "3.3.0" }
          ],
          "supervisorId": "O+14439=481WA001",
          "SXLS": [
-            { "name": "traffic_light_controller", "version": "1.3.0" },
-            { "name": "variable_message_sign", "version": "1.3.4" },
-            { "name": "variable_message_sign", "rejected": 2, "reason": "Supervisor only supports 2.0.0" }
+            { "name": "traffic_light_controller", "version": "1.4.0" },
+            { "name": "traffic_light_controller/advanced", "rejected": 2, "reason": "Supervisor only supports 2.0.0" },
+            { "name": "variable_message_sign", "version": "1.0.2" }
          ],
          "receiveAlarms": false
    }
 
 JSon code 25: A Version Response message
 
-In this example, the SXL ``traffic_light_controller`` will be used, as well as the 
-SXL ``variable_message_sign``.
+In this example, the SXL ``traffic_light_controller`` will be used with site
+version 1.3.0 and supervisor version 1.4.0. The SXL
+``variable_message_sign`` will be used with site version 1.0.6 and supervisor
+version 1.0.2.
 
-The SXL ``traffic_light_controller/advanced`` is not used, either because the supervisor
-does not support the version 1.3.4 specified by the site, or the supervisor does not want to use it.
+The SXL ``traffic_light_controller/advanced`` is not used because the
+supervisor only supports the incompatible major version 2.0.0.
 
-The ``SXLS`` array may be empty if no SXLs will be used.
+The ``SXLS`` array may be empty only if the request's ``SXLS`` array was empty.
 
 The following table describes variable content of the message:
 
@@ -1730,7 +1745,7 @@ The following table describes variable content of the message:
    step          string   Must be set to 'Response'.
    supervisorId  string   The id of the supervisor.
    RSMP          array    Core version used. Array with exactly one object with the attribute ``vers`` set to the core version string.
-   SXLS          array    List of SXLS which will be used for communication.
+   SXLS          array    List of SXLs which will be used for communication, and SXLs rejected by the supervisor.
    receiveAlarms boolean  Optional. If set to false the site must not send alarms to the supervisor.
    ============= ======== ===============
 
@@ -1746,10 +1761,16 @@ Each item in the ``SXLS`` array must be an object with the following content:
    Element   Type     Description
    ========= ======== ====================
    name      string   SXL name, e.g. ``traffic_light_controller``, matching the name in the Version request.
-   version   string   Version of the SXL, e.g. "1.3.0", matching the version in the Version request.
+   version   string   Required if the SXL is accepted. Version supported by the supervisor. It can differ from the site version in the Version request.
    rejected  integer  (Optional) If the SXL will not be used, then a code indicating why (see table below), otherwise omitted.
    reason    string   (Optional) If SXL will not be used, then this is a human readable explanation of why, otherwise omitted.
    ========= ======== ====================
+
+Each SXL name must occur exactly once in the Version response. If the request
+contains candidates from more than one major version of an SXL, the accepted
+supervisor version identifies the selected major version. A response is
+invalid if it omits a requested SXL name, repeats a name, or contains a name
+which was not included in the request.
 
 .. tabularcolumns:: |\Yl{0.11}|\Yl{0.50}|
 
@@ -1759,7 +1780,7 @@ Each item in the ``SXLS`` array must be an object with the following content:
    Code    Description
    ======= ====================
    1       SXL not supported.
-   2       No matching version of the SXL supported.
+   2       No compatible version of the SXL supported.
    3       SXL not needed/wanted.
    ======= ====================
 
@@ -1769,14 +1790,6 @@ A site and a supervisor can only communicate if the core versions are exactly th
 major, minor and patch versions match.
 The core version string returned by the supervisor in the version response must therefore be
 the same as one of the core version strings sent by the site in the Version request.
-
-SXL Version Compatibility
-"""""""""""""""""""""""""
-An SXL can be used if the site and the supervisor support the exact same version, i.e. both
-major, minor and patch versions match.
-A SXL version string returned by the supervisor in the version response must therefore be
-the same as the SXL version strings sent by the site in the Version request.
-
 
 .. _component-list:
 

--- a/source/applicability/error_handling.rst
+++ b/source/applicability/error_handling.rst
@@ -26,26 +26,21 @@ table below.
    |                 | v       | ``null``  |
    +-----------------+---------+-----------+
 
-SXL mismatch
-^^^^^^^^^^^^
+SXL errors and version differences
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If there is a mismatch of the SXL when receiving a command, status or alarm
-request, which is not caught during communication handshake (See
-:ref:`rsmpsxl-version`), then this is considered a serious error resulting in
-MessageNotAck.
+If a command, status or alarm uses an SXL which was not accepted during the
+Version exchange, the receiver must respond with MessageNotAck.
 
-This includes:
-
-* unknown alarm/status/command code id (``aCId``, ``sCI``, ``cCI``) for the
-  corresponding component type
-
-* unknown name (``n``) in arguments or return values
+A known attribute with an invalid value or data type also results in
+MessageNotAck. Handling of unknown code ids and attributes when compatible SXL
+versions differ is defined in :ref:`sxl-version-error-handling`.
 
 Unimplemented statuses or commands
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If a status (``sCI``) or command (``cCI``) is recognized in relation to its SXL
-but not unimplemented, the site answers with CommandResponse/StatusResponse where
+but not implemented, the site answers with CommandResponse/StatusResponse where
 the values are set according to the table below.
 
 .. table:: Unimplemented
@@ -67,8 +62,8 @@ the values are set according to the table below.
 Incomplete commands
 ^^^^^^^^^^^^^^^^^^^
 
-If not all arguments are included in a CommandRequest, then this is considered
-a serious error resulting in MessageNotAck.
+If not all required arguments are included in a CommandRequest, then this is
+considered a serious error resulting in MessageNotAck.
 
 
 .. _more-than-one-command:
@@ -79,4 +74,3 @@ More than one command
 If more than one command (``cCI``) is included in a single CommandRequest or
 CommandResponse, then this is considered a serious error resulting in
 MessageNotAck.
-

--- a/source/applicability/sxl.rst
+++ b/source/applicability/sxl.rst
@@ -60,7 +60,9 @@ Note: Some legacy SXLs use names without a country code or region, e.g. ``tlc`` 
 
 Version
 ^^^^^^^
-An SXL has a version, e.g. ``1.3.1``, which must follow Semantic Versioning conventions.
+An SXL has a version, e.g. ``1.3.1``, which must use the Semantic
+Versioning core format ``MAJOR.MINOR.PATCH``. Numeric identifiers must not
+contain leading zeroes.
 
 Given a version number MAJOR.MINOR.PATCH, you must increment the:
 
@@ -68,7 +70,12 @@ Given a version number MAJOR.MINOR.PATCH, you must increment the:
 - MINOR version when you add functionality in a backward compatible manner
 - PATCH version when you make backward compatible bug fixes
 
-Preview and build info cannot be used as part of version strings.
+Prerelease and build information cannot be used as part of SXL version
+strings.
+
+Semantic Versioning applies to both the message structure and behavior defined
+by an SXL. Detailed versioning and communication requirements are defined in
+:ref:`sxl-version-compatibility`.
 
 SXL versions are used to determine whether a site and the supervisor has compatible versions,
 and when resolving dependencies between SXLs.

--- a/source/applicability/sxl_version_compatibility.rst
+++ b/source/applicability/sxl_version_compatibility.rst
@@ -1,0 +1,440 @@
+.. _sxl-version-compatibility:
+
+SXL Version Compatibility
+=========================
+
+Intention
+---------
+
+SXL version compatibility allows a site and a supervisor to upgrade
+independently while continuing to use the functionality shared by their SXL
+versions. It avoids requiring simultaneous upgrades for every backward
+compatible SXL change.
+
+Compatibility does not make functionality added in a newer version available
+to a party using an older version. If all functionality is required, the
+parties must use versions which provide that functionality.
+
+The rules in this section apply equally to communication between sites. In
+that case, *site* means the follower site and *supervisor* means the leader
+site.
+
+Overview
+--------
+
+Compatibility relies on two requirements: SXL releases must preserve both
+structure and behavior according to Semantic Versioning, and communicating
+parties must use the exact peer versions exchanged during negotiation when
+deciding which functionality can be used. Additional informational data can
+sometimes be ignored. Requests and actions should only use functionality the
+receiver supports; otherwise, the receiver rejects them as specified below.
+
+An SXL version follows `Semantic Versioning 2.0.0 <https://semver.org/spec/v2.0.0.html>`_
+and consists of
+``MAJOR.MINOR.PATCH``. SXL versions with the same non-zero major version are
+compatible. Their minor and patch versions do not need to match. Versions with
+different major versions are incompatible.
+
+Prerelease and build information are not allowed in SXL version strings.
+
+Semantic Versioning does not guarantee compatibility for major version zero.
+For RSMP SXL negotiation, ``0.y.z`` versions are therefore considered
+compatible only when all three version numbers match.
+
+.. list-table:: SXL version compatibility examples
+   :header-rows: 1
+
+   * - Site version
+     - Supervisor version
+     - Compatible
+   * - 1.3.0
+     - 1.3.4
+     - Yes; only the patch versions differ.
+   * - 1.3.0
+     - 1.4.0
+     - Yes; only the minor versions differ.
+   * - 1.3.0
+     - 2.0.0
+     - No; the major versions differ.
+   * - 0.3.0
+     - 0.3.1
+     - No; major version zero requires an exact match.
+
+For a compatible pair, the *lower version* and *higher version* are determined
+using Semantic Versioning precedence. The *shared API* is the API of the lower
+minor version. Patch releases have the same API.
+
+SXL public API
+--------------
+
+Semantic Versioning applies to the complete public API of an SXL, including
+both message structure and behavior.
+
+Structural API
+^^^^^^^^^^^^^^
+
+The structural API includes:
+
+* the SXL name and prefix
+* component types
+* alarm, status and command code ids and the component types to which they
+  apply
+* argument and return value names and the code id to which each belongs
+* data types, units, allowed values and constraints
+* whether an argument is required or optional
+* command operation identifiers and the command to which each belongs
+* alarm categories and priorities
+* functional positions, functional states and aggregated status definitions
+* dependencies on other SXLs
+
+Behavioral API
+^^^^^^^^^^^^^^
+
+The behavioral API is every externally observable requirement defined by the
+SXL. This includes:
+
+* when and why a status value changes
+* when status updates are triggered
+* when an alarm becomes active or inactive
+* the conditions for acknowledging, suspending and resuming an alarm
+* the preconditions, effects and side effects of a command
+* command completion, failure and return value semantics
+* default behavior when an optional argument is omitted
+* state transitions, ordering and timing requirements
+* how alarms and equipment state affect aggregated status
+* error behavior defined by the SXL
+
+Descriptions which define these behaviors are normative parts of the API. SXL
+authors must define behavior precisely enough to determine whether a later
+change is backward compatible.
+
+Versioning requirements
+-----------------------
+
+Patch versions
+^^^^^^^^^^^^^^
+
+A patch release must not change the structural or behavioral API. It can fix
+spelling, examples, metadata or non-normative documentation without changing
+the behavior required by the published SXL. An implementation can also be
+fixed to conform to the behavior already required by the SXL.
+
+If correcting an SXL changes a normative requirement or externally observable
+behavior, the change is not a patch change. It requires a minor or major
+version according to its compatibility impact.
+
+Minor versions
+^^^^^^^^^^^^^^
+
+A minor release can add functionality, but must preserve the complete shared
+API. For the same inputs and relevant state, use of the shared API must have
+the same externally observable behavior in both versions.
+
+A minor release can:
+
+* add a component type
+* add an alarm, status or command code id
+* add an alarm, status or command return value
+* add an optional argument to an existing command
+* deprecate an existing API element without removing or changing it
+* add behavior which is only observable through a new API element
+
+The SXL must identify the version in which each new API element is introduced.
+This includes an argument or return value added to an existing alarm, status
+or command code id, and applying an existing code id to an additional
+component type. An implementation must retain enough of this version
+information to determine the shared API for every lower minor version with
+which it communicates.
+
+An argument added to an existing command must be optional. Omitting it must
+produce the behavior defined before the argument was added. The new argument
+must not be required to preserve existing safety or operational behavior.
+
+A minor release must not:
+
+* remove, rename or repurpose an existing API element
+* change a data type, unit, allowed value set or constraint
+* make an optional argument required or change an existing default
+* change the meaning or update behavior of an existing status
+* change the trigger, clearing condition, category or priority of an existing
+  alarm
+* change the preconditions, effects, side effects, completion or failure
+  behavior of an existing command
+* change an existing functional position, functional state or aggregated
+  status meaning
+* make existing behavior depend on a newly added component, message or
+  attribute
+
+Any change prohibited in a minor release requires a new major version.
+
+Major versions
+^^^^^^^^^^^^^^
+
+A major version is required for any backward incompatible structural or
+behavioral change. Different major versions cannot be accepted as compatible
+during Version negotiation. Migration therefore requires the parties to be
+configured to advertise compatible major versions or to be upgraded together.
+
+Dependencies
+^^^^^^^^^^^^
+
+Changes to SXL dependencies follow the same rules. A dependency can be added
+or updated in a minor release only if the resulting structural and behavioral
+API remains backward compatible. Dependency changes which alter the existing
+API or its behavior require a new major version.
+
+Compatibility is negotiated separately for every SXL listed in the Version
+messages. Accepting one SXL does not implicitly accept another SXL on which it
+depends. See :ref:`sxl-dependency-resolution` and :ref:`sxl-list`.
+
+Version negotiation
+-------------------
+
+For each SXL, the Version request identifies the latest exact version supported
+by the site in each compatibility series. Each non-zero major version is one
+series. Because major-version-zero versions require an exact match, each
+supported ``0.y.z`` version is a separate series. The same SXL name can
+therefore occur more than once, but at most once in each series.
+
+The Version response contains exactly one result for each distinct SXL name in
+the request. If the SXL is accepted, the response identifies the exact version
+supported by the supervisor. The response version selects the compatible
+series but does not select a common exact version and does not need to match
+the site version.
+
+If more than one site candidate is compatible, the supervisor must select the
+candidate with the highest Semantic Versioning precedence. For a selected
+non-zero major version, the supervisor must return the latest version it
+supports in that major version. A major-version-zero candidate must match
+exactly. Both parties must retain the selected site candidate and the
+supervisor version for as long as the connection remains established.
+
+For example, if a site advertises versions 1.5.0 and 2.1.0 of an SXL and the
+supervisor supports versions 1.4.0 and 2.0.0, the supervisor selects the 2.x
+series and returns 2.0.0. The site version used for compatibility decisions is
+2.1.0 and the supervisor version is 2.0.0.
+
+An SXL for which no compatible version exists is rejected in the Version
+response. This does not prevent the connection from being established and
+does not affect other accepted SXLs. The RSMP Core version must still match
+exactly as described in :ref:`rsmpsxl-version`.
+
+.. _sxl-version-error-handling:
+
+Communication using compatible versions
+----------------------------------------
+
+General rules
+^^^^^^^^^^^^^
+
+Handling is determined by the exact SXL versions exchanged during Version
+negotiation, the message type and the direction of the message. A receiver
+must not decide whether to ignore an unknown element by interpreting whether
+the element appears informational or operational.
+
+The rules below apply to SXL-defined code ids, argument and return value names
+(``n``), and command operation identifiers (``cO``). A code id is evaluated
+for the addressed component type, a name is evaluated for its code id, and an
+operation is evaluated for its command. The rules do not apply to
+unknown RSMP Core JSON fields, which are validated according to the negotiated
+RSMP Core version.
+
+An SXL element is outside the shared API when it is not defined by the lower
+of the two minor versions. This is true even if the receiver recognizes the
+element from its own higher version.
+
+An SXL element missing from either the receiver's or the sender's advertised
+SXL version results in MessageNotAck, except in the cases listed below. When
+MessageNotAck is required, the receiver must not process any part of the
+message.
+
+Exceptions exist only when the site uses the higher minor version. No
+exceptions apply when the supervisor uses the higher minor version.
+
+The equal-minor-version case needs no compatibility exception. Patch releases
+have the same API, so an element outside that API results in MessageNotAck when
+the minor versions are equal, even if the patch versions differ.
+
+Major-version-zero pairs must match exactly, so the higher-minor exception
+does not apply to them.
+
+An alarm, status or command code id must be defined by both parties'
+advertised SXL versions. Otherwise it always results in MessageNotAck,
+regardless of the version relationship or message direction, unless the
+complete informational message is ignored because it concerns an unsupported
+newer component type as specified below. A code id must also be defined for the
+addressed component type by both versions, subject to the same exception. A
+known element with an invalid data type or value also always results in
+MessageNotAck unless the complete message is ignored under that exception.
+
+A party sending a request or action should use the receiver's advertised SXL
+version to determine the allowed code ids, names and operations. If it sends
+an SXL element outside the shared API, the receiver must handle the message as
+specified below, and the sender must be prepared for MessageNotAck. The
+unsupported request or action does not invalidate the negotiated SXL
+compatibility or the connection.
+
+When the rules below permit a return value outside the shared API to be
+ignored, the receiver ignores the complete array entry containing that ``n``.
+It processes the remaining entries and sends MessageAck if the rest of the
+message is valid. A lower-version receiver does not need to implement or
+inspect the higher SXL version to make this decision.
+
+The decision to ignore is based only on the version relationship, message type
+and direction. In an allowed position, the lower-version receiver therefore
+treats every unrecognized ``n`` as an additive extension. The sender remains
+responsible for sending only names defined by its own SXL version.
+
+Status compatibility
+^^^^^^^^^^^^^^^^^^^^
+
+A supervisor using a lower minor version must ignore any ``sS`` entry in a
+StatusResponse or StatusUpdate whose ``n`` is not defined for its ``sCI`` by
+the supervisor's SXL version and process the rest of the message.
+
+A supervisor should only use return value names defined in the site's
+advertised version. A supervisor using a higher version should therefore not
+request or subscribe to return values added after the site's version. If it
+does, the site sends MessageNotAck and processes no part of the request.
+
+A site using a higher version must continue to support requests and
+subscriptions defined by the lower version. It must return the same meaning,
+data type, units and value constraints, and must preserve the defined update
+and ``sendOnChange`` behavior.
+
+StatusResponse and StatusUpdate should contain only requested or subscribed
+return values. If a site using the higher minor version includes a return
+value added in that version, the lower-version supervisor handles it as
+specified above.
+
+Adding a status code or return value in a minor release is therefore
+compatible: an older supervisor does not request it, and a newer supervisor
+should not request it from a site whose advertised version predates it.
+
+Alarm compatibility
+^^^^^^^^^^^^^^^^^^^
+
+A supervisor using a lower minor version must ignore any ``rvs`` entry in an
+alarm message whose ``n`` is not defined for the message's ``aCId`` by the
+supervisor's SXL version and process the rest of the message.
+
+For an alarm code present in the shared API, a site using a higher version must
+preserve the alarm trigger, clearing condition, category, priority, state
+transitions and acknowledgment and suspension behavior of the lower version.
+
+An Alarm sent by a site using the higher minor version can contain return
+values added in that version. A supervisor using the lower version handles
+them as specified above.
+
+A site must not send alarm codes added after the supervisor's advertised
+version. If the complete alarm set is operationally required, compatible but
+different minor versions must not be used.
+
+Alarm requests, acknowledgments, suspensions and resumptions ask the site to
+act on a specific alarm. The supervisor should only use alarm code ids present
+in the site's version.
+
+Command compatibility
+^^^^^^^^^^^^^^^^^^^^^
+
+A supervisor using a lower minor version must ignore any ``rvs`` entry in a
+CommandResponse whose ``n`` is not defined for its ``cCI`` by the supervisor's
+SXL version and process the rest of the message.
+
+A command can change equipment state, so unknown command inputs must never be
+silently ignored. A supervisor should use arguments and operations defined in
+the site's version. If an argument or operation is outside the shared API, the
+site must send MessageNotAck and must not execute any part of the command.
+
+An argument added to an existing command in a minor release must be optional,
+and omission must preserve the behavior of the lower version. A supervisor
+using the higher version should omit that argument when communicating with a
+site using the lower version.
+
+A site using the higher version must execute a shared command with the same
+preconditions, effects, side effects, completion and failure behavior as the
+lower version when the new optional argument is omitted.
+
+A CommandResponse sent by a site using the higher minor version can contain
+return values added in that version. A supervisor using the lower version
+handles them as specified above.
+
+Aggregated status compatibility
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+AggregatedStatus represents the site as a whole and is not sent separately for
+each component. AggregatedStatusRequest requests that site-wide status. The
+component-type compatibility rules below therefore do not apply to either
+message. A minor or patch release must preserve the existing functional
+position, functional state and state-bit meanings.
+
+Component types
+^^^^^^^^^^^^^^^
+
+A minor release can add component types. A ComponentList from a site using the
+higher version can therefore contain a component type unknown to a supervisor
+using the lower version. The supervisor must not reject the complete
+ComponentList solely because of that component type, but must treat the
+component as unsupported.
+
+A lower-version supervisor must ignore an alarm message, StatusResponse,
+StatusUpdate or CommandResponse concerning an unsupported newer component
+type. It must send MessageAck if the message is valid according to RSMP Core.
+Because the complete message is ignored, its SXL-defined code id and content do
+not need to be recognized by the supervisor.
+
+A lower-version supervisor must not send a StatusRequest, StatusSubscribe,
+StatusUnsubscribe, alarm request, acknowledgment, suspension or resumption, or
+CommandRequest directed at an unsupported component type. If the site
+nevertheless receives such a message, it must send MessageNotAck and must not
+process any part of the message.
+
+A component type not defined by the sender's advertised SXL version always
+results in MessageNotAck. In any other version relationship, a component type
+not defined by both advertised SXL versions also results in MessageNotAck.
+
+A minor release must not change the meaning of existing functional positions,
+functional states or aggregated status values. New alarms or components can
+affect aggregated status only according to the existing RSMP Core and SXL
+rules.
+
+Examples
+--------
+
+Assume a site uses version 1.4.0 and a supervisor uses version 1.3.0:
+
+* Version 1.4.0 adds an Alarm return value named ``colors``. The supervisor
+  processes the known alarm and ignores ``colors``.
+* Version 1.4.0 adds a status return value. The supervisor does not know the
+  value and therefore does not request or subscribe to it. If the site
+  includes it in a StatusResponse or StatusUpdate, the supervisor ignores that
+  ``sS`` entry.
+* Version 1.4.0 adds an optional command argument. The supervisor does not send
+  it. The site performs the command with the behavior defined by version
+  1.3.0.
+* Version 1.4.0 adds a CommandResponse return value. The supervisor ignores the
+  corresponding ``rvs`` entry and processes the remaining response.
+
+If the supervisor uses version 1.4.0 and the site uses version 1.3.0, the
+supervisor should omit a command argument added in version 1.4.0. If it sends
+the argument nevertheless, the site sends MessageNotAck and does not execute
+any part of the command. The connection remains established.
+
+When the sender uses version 1.3.0 and the receiver uses version 1.4.0, an SXL
+element not defined by the sender's advertised version results in
+MessageNotAck, even if the receiver recognizes it from version 1.4.0. An
+unknown SXL element between versions 1.3.0 and 1.3.1 also results in
+MessageNotAck because patch releases have the same API.
+
+Compatibility verification
+--------------------------
+
+Before publishing a minor or patch release, the complete structural and
+behavioral API must be compared with the previous release. A minor release
+should document every added API element and the behavior used when it is not
+available to an older peer.
+
+Implementations should test communication in both directions between the new
+version and supported lower minor and patch versions. Tests must cover status
+requests and subscriptions, alarm state handling, commands and their side
+effects, error handling and aggregated status.

--- a/source/applicability/transport_of_data.rst
+++ b/source/applicability/transport_of_data.rst
@@ -130,21 +130,22 @@ implicit in the following figure.
 
 1. Site sends RSMP / SXL version (according to section :ref:`rsmpsxl-version`).
 
-2. The supervision system verifies the RSMP version, SXL version and site id.
-   If there is a mismatch the sequence does not proceed.
-   (see section :ref:`communication-rejection`)
+2. The supervision system verifies the RSMP version and site id, and determines
+   which SXLs have compatible versions. If the RSMP version or site id cannot
+   be accepted, the sequence does not proceed. (See
+   :ref:`communication-rejection`.)
 
 3. The supervision system sends RSMP / SXL version (according to section
    :ref:`rsmpsxl-version`).
 
-4. The site verifies the RSMP version, SXL version and site id.
-   If there is a mismatch the sequence does not proceed.
-   (see section :ref:`communication-rejection`)
+4. The site verifies the RSMP version, supervisor id and the compatibility of
+   each accepted SXL. If the response is invalid, the sequence does not
+   proceed. (See :ref:`communication-rejection`.)
 
 
-5. The latest version of RSMP that both communicating parties exchange in the
-   RSMP/SXL Version is implicitly selected and used in any further RSMP
-   communication.
+5. The exact RSMP version in the Version response is used for further
+   communication. For each accepted SXL, each party retains both advertised
+   versions and uses the rules in :ref:`sxl-version-error-handling`.
 
 6. The site sends a Watchdog (according to section :ref:`watchdog`)
 
@@ -156,8 +157,8 @@ implicit in the following figure.
    statuses are allowed to be sent
 
 10. Aggregated status (according to section :ref:`aggregated-status-message`).
-    If no component for aggregated status is defined in the signal exchange list
-    then no aggregated status message is sent.
+    If aggregated status is not defined in the signal exchange list, no
+    aggregated status message is sent.
 
 11. All alarms (including active, inactive, suspended, unsuspended and acknowledged)
     are sent. (according to section :ref:`alarm-messages`).
@@ -176,15 +177,10 @@ current ones based on their older alarm timestamps. Any buffered alarm events
 that contains the exact same alarm event and timestamp as sent when sending all
 alarms should not be sent again.
 
-Since only one version of the signal exchange list is allowed to be used
-at the communication establishment (according to the version message),
-each connected site must either:
-
-* Use the same version of the signal exchange list via the same
-  RSMP connection
-* Connect to separate supervision systems (e.g. using separate ports)
-* Connect to a supervision system that can handle separate signal exchange
-  lists depending on the RSMP / SXL version message from the site
+For each accepted SXL, a connection uses one selected site version candidate
+and one supervisor version. A site connected to multiple supervisors must
+track the accepted SXLs and both selected versions separately for each
+connection.
 
 .. _communication-establishment-between-sites:
 
@@ -208,20 +204,21 @@ implicit in the following figure.
 1. The follower site sends RSMP / SXL version (according to section
    :ref:`rsmpsxl-version`).
 
-2. The leader site verifies the RSMP version, SXL version and site id.
-   If there is a mismatch the sequence does not proceed.
-   (see section :ref:`communication-rejection`)
+2. The leader site verifies the RSMP version and site id, and determines which
+   SXLs have compatible versions. If the RSMP version or site id cannot be
+   accepted, the sequence does not proceed. (See
+   :ref:`communication-rejection`.)
 
 3. The leader site sends RSMP / SXL version (according to section
    :ref:`rsmpsxl-version`).
 
-4. The follower site verifies the RSMP version, SXL version and site id.
-   If there is a mismatch the sequence does not proceed.
-   (see section :ref:`communication-rejection`)
+4. The follower site verifies the RSMP version, site id and the compatibility
+   of each accepted SXL. If the response is invalid, the sequence does not
+   proceed. (See :ref:`communication-rejection`.)
 
-5. The latest version of RSMP that both communicating parties exchange in the
-   RSMP/SXL Version is implicitly selected and used in any further RSMP
-   communication.
+5. The exact RSMP version in the Version response is used for further
+   communication. For each accepted SXL, each party retains both advertised
+   versions and uses the rules in :ref:`sxl-version-error-handling`.
 
 6. The follower site sends Watchdog (according to section :ref:`watchdog`)
 
@@ -233,8 +230,8 @@ implicit in the following figure.
    statuses are allowed to be sent
 
 10. Aggregated status (according to section :ref:`aggregated-status-message`)
-    If no component for aggregated status is defined in the signal exchange list
-    then no aggregated status message is sent.
+    If aggregated status is not defined in the signal exchange list, no
+    aggregated status message is sent.
 
 For communication between sites the following applies:
 
@@ -264,10 +261,11 @@ Communication rejection
 During RSMP/SXL Version exchange each communicating party needs to verify:
 
 * RSMP version(s)
-* SXL version
-* Site id
+* compatibility of each accepted SXL version
+* site or supervisor id
 
-If there is a mismatch of SXL, Site id or unsupported version(s) of RSMP then:
+If the site or supervisor id is not accepted, no RSMP version is supported by
+both parties, or a Version response accepts an incompatible SXL version, then:
 
 1. The communication establishment sequence does not proceed
 2. The receiver of the RSMP/SXL version message sends a MessageNotAck with
@@ -275,11 +273,17 @@ If there is a mismatch of SXL, Site id or unsupported version(s) of RSMP then:
    ``RSMP versions [3.1.5] requested, but only [3.1.1,3.1.2,3.1.3,3.1.4] supported``
 3. The connection is closed
 
+If no compatible version exists for an SXL, the supervisor rejects that SXL in
+the Version response as described in :ref:`rsmpsxl-version`. This does not
+prevent the connection from being established and does not cause the
+connection to be closed.
+
 .. image:: /img/msc/communication-rejection.png
    :align: center
 
-Is it not allowed to disconnect for any other circumstance other than mismatch
-during RSMP/SXL Version or :ref:`missing message acknowledgement<message-acknowledgement>`
+It is not allowed to disconnect for any other circumstance other than failed
+verification during RSMP/SXL Version exchange or
+:ref:`missing message acknowledgement<message-acknowledgement>`
 unless there is a communication disruption.
 
 .. _communication-disruption:

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -15,6 +15,8 @@ The full list of changes between version 3.3.0 and 3.2.2 can be viewed on github
 - Allow all JSON types. :issue:`195`
 - Component id format B, remove references to STA. :issue:`178`
 - Allow optional commands. :issue:`181`
+- Allow compatible minor and patch versions of an SXL to communicate and
+  negotiate multiple supported major-version series. :issue:`250`
 
 **Minor changes**
 

--- a/test/schema/version.rb
+++ b/test/schema/version.rb
@@ -35,7 +35,7 @@ describe 'Version' do
     "SXLS" => [
       {
         "name" => "traffic_light_controller",
-        "version" => "1.3.0"
+        "version" => "1.4.0"
       },
       {
         "name" => "variable_message_sign",
@@ -134,6 +134,28 @@ describe 'Version' do
     expect( validate(request) ).not.to be_nil
   end
 
+  it 'accepts SXL versions in SemVer core format' do
+    ['0.0.0', '1.2.3', '123.456.789'].each do |version|
+      request['SXLS'].first['version'] = version
+      expect(validate(request)).to be_nil
+    end
+  end
+
+  it 'rejects SXL versions outside SemVer core format' do
+    ['1.2', '01.2.3', '1.02.3', '1.2.03', '1.2.3-alpha', '1.2.3+build', '1.2.3junk'].each do |version|
+      request['SXLS'].first['version'] = version
+      expect(validate(request)).not.to be_nil
+    end
+  end
+
+  it 'requires SemVer core format in every SXL version field' do
+    request['SXL'] = '1.2.3-alpha'
+    expect(validate(request)).not.to be_nil
+
+    response['SXLS'].first['version'] = '1.2.3+build'
+    expect(validate(response)).not.to be_nil
+  end
+
   it 'catches missing SXLS in request' do
     request.delete 'SXLS'
     expect( validate(request) ).not.to be_nil
@@ -148,6 +170,20 @@ describe 'Version' do
   it 'catches malformed SXLS item in request' do
     request['SXLS'] = [{ 'name' => 'traffic_light_controller' }]
     expect( validate(request) ).not.to be_nil
+  end
+
+  it 'accepts candidates from different SXL major versions' do
+    request['SXLS'] << {
+      'name' => 'traffic_light_controller',
+      'version' => '2.0.0',
+      'prefix' => 'tlc/'
+    }
+    expect(validate(request)).to be_nil
+  end
+
+  it 'catches an identical duplicate SXL candidate' do
+    request['SXLS'] << request['SXLS'].first.dup
+    expect(validate(request)).not.to be_nil
   end
 
   it 'catches bad request step' do


### PR DESCRIPTION
This PR is a draft proposal for allowing compatible SXLs to communicate directly.

The compatibility rules are defined explicitly for status, alarm, command, and component messages.

The Version request now advertises the latest supported SXL version in each compatibility (major) series.
The Version response contains one result per SXL name and, when accepted, selected series. Both parties remember the selected site and supervisor versions when determining the shared api.

Note that versions 0.x.x are defined as prereleases. Since there is no requirements for compatibility for those, exact version match is require for 0.x.x versions.

Allowing could provide flexibility in upgrade paths, but is a significant change that we should consider carefully. This PR is mean as a help for such discussion, by having something more concrete to look at. 

Added a new doc that explains compatibility rules:
https://github.com/rsmp-nordic/rsmp_core/blob/49d5ca36b006e92c75581ed7dc418468952529ae/source/applicability/sxl_version_compatibility.rst

Addresses the SXL part of #250