### PR TITLE
SemVer evolution

### DIFF
--- a/source/applicability/basic_structure.rst
+++ b/source/applicability/basic_structure.rst
@@ -1763,12 +1763,37 @@ Each item in the ``SXLS`` array must be an object with the following content:
    3       SXL not needed/wanted.
    ======= ====================
 
-Core Version Compatibility
-""""""""""""""""""""""""""
-A site and a supervisor can only communicate if the core versions are exactly the same, i.e. both
-major, minor and patch versions match.
-The core version string returned by the supervisor in the version response must therefore be
-the same as one of the core version strings sent by the site in the Version request.
+Core Versioning and Compatibility
+"""""""""""""""""""""""""""""""""
+RSMP Core versions follow Semantic Versioning (SemVer). Given a version number
+MAJOR.MINOR.PATCH, the:
+
+* MAJOR version is incremented for incompatible changes
+* MINOR version is incremented when functionality is added in a backward
+  compatible manner, or existing functionality is deprecated
+* PATCH version is incremented for backward compatible corrections
+
+The public protocol interface includes message types and structures,
+attributes, data types, permitted values and their meanings, required message
+sequences, and error handling. Removing part of this interface, restricting
+previously permitted use, or changing its meaning is an incompatible change.
+
+Deprecated functionality remains valid and retains its meaning for the
+remainder of the current major version. Implementations must continue to
+accept previously valid use of deprecated functionality. Deprecation may
+recommend an alternative for new implementations, but removal or restriction
+requires a new major version.
+
+A site and a supervisor can currently communicate only if the Core versions
+are exactly the same, i.e. the major, minor and patch versions all match. The
+Core version string returned by the supervisor in the Version response must
+therefore be the same as one of the Core version strings sent by the site in
+the Version request.
+
+The exact-match requirement is independent of Semantic Versioning and does
+not permit incompatible changes in minor or patch releases. Preserving
+compatibility makes it possible to relax the version negotiation requirement
+in a future Core version.
 
 SXL Version Compatibility
 """""""""""""""""""""""""

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -26,6 +26,7 @@ The full list of changes between version 3.3.0 and 3.2.2 can be viewed on github
 
 - Remove reference to Datex II. :issue:`185`
 - Clarify aggregated status. :issue:`200`
+- Define Semantic Versioning and deprecation rules for RSMP Core.
 - Add security considerations, clarify that communication protection is
   external to RSMP Core, and remove operational TLS recommendations.
 


### PR DESCRIPTION
Add a section that explains how the core spec follow SemVer when it's updated. I think it's good to explicitly state this, as it will guide our own work also also help implementers by clarifying expectations.

But it's a promise, so we should only add it if we intent to follow it.

For example, in a minor release, an attribute may be deprecated, but previously valid values cannot be prohibited or have their meaning changed. The specification may recommend setting the attribute to a particular value, such as null, but cannot require that value. Receivers must continue to accept and interpret all previously valid values as before.

I think we have sometimes used a looser interpretation, but I believe the above is the correct one.

The official SemVer specification does not discuss nullable fields specifically, but the interpretation follows directly from these rules:

- [Rule 7](https://semver.org/spec/v2.0.0.html#spec-item-7): minor releases introduce backward-compatible functionality and may mark public API functionality as deprecated.
- [Rule 8](https://semver.org/spec/v2.0.0.html#spec-item-8): any backward-incompatible public API change requires a major release.
- [Deprecation FAQ](https://semver.org/spec/v2.0.0.html#how-should-i-handle-deprecating-functionality): deprecation should occur in a minor release before functionality is removed in a major release.

Therefore, if non-null values are part of the declared public API, requiring null makes previously valid usage invalid. That is a backward-incompatible restriction and consequently requires a major release. Deprecating the attribute and recommending null, while continuing to accept earlier values, fits a minor release.

Old behavior may become discouraged, but not invalid or interpreted differently in a minor update.